### PR TITLE
PS-11185 - Group replication test with docker containers

### DIFF
--- a/test_scripts/ps/group-replication/.gitignore
+++ b/test_scripts/ps/group-replication/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -42,8 +42,8 @@ cd test_scripts/ps/group-replication
 pytest -v test_basic.py
 ```
 
-The fixture brings up 3 containers (by default `ps0-1`, `ps0-2`, `ps0-3`) on a per-worker
-`grnet-<workerid>` network (e.g. `grnet-0` when running serially, or `grnet-gw0` under pytest-xdist), bootstraps the cluster via mysqlsh, runs the tests,
+The fixture brings up 3 containers (by default `ps<workerid>-1`, `ps<workerid>-2`, `ps<workerid>-3`) on a per-worker
+`grnet-<workerid>` network (e.g. `grnet-0` / `ps0-1..3` when running serially, or `grnet-gw0` / `psgw0-1..3` under pytest-xdist), bootstraps the cluster via mysqlsh, runs the tests,
 then removes containers, volumes, and the network. Expect ~1 minute end-to-end.
 
 ## Failover test (sysbench)

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -41,7 +41,7 @@ pytest -v test_basic.py
 ```
 
 The fixture brings up 3 containers (by default `ps0-1`, `ps0-2`, `ps0-3`) on a per-worker
-`grnet-<workerid>` network (e.g. `grnet-master`), bootstraps the cluster via mysqlsh, runs the tests,
+`grnet-<workerid>` network (e.g. `grnet-0` when running serially, or `grnet-gw0` under pytest-xdist), bootstraps the cluster via mysqlsh, runs the tests,
 then removes containers, volumes, and the network. Expect ~1 minute end-to-end.
 
 ## Failover test (sysbench)

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -79,7 +79,7 @@ Relevant `GroupReplication` helpers: `get_primary()`, `stop_node()`,
 `test_scaling.py` exercises elastic membership changes under load:
 
 ```bash
-GR_VERBOSE=1 /Users/plavi/Development/percona/server-qa/.venv/bin/pytest -v test_scaling.py
+GR_VERBOSE=1 pytest -v test_scaling.py
 ```
 
 What it does: load initial data with sysbench, **scale up** the cluster from 3 to 5

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -80,6 +80,50 @@ pytest -s test_basic.py        # don't capture stdout/stderr (live container log
 pytest --tb=short test_basic.py  # shorter tracebacks
 ```
 
+### Verbose mode (framework step logging)
+
+By default the framework is silent until something fails. Enable verbose mode to
+log a `[GR]` message before each high-level step (create network, start node,
+bootstrap, add instance, verify, checksum, destroy) so you can follow a run live.
+
+Enable it with the `GR_VERBOSE` env var:
+
+```bash
+GR_VERBOSE=1 pytest -v test_basic.py
+```
+
+Sample output (appears in pytest's live log — no `-s` needed; each line is
+timestamped to help debug timing/hangs):
+
+```
+2026-05-27 14:24:09.512 [GR] create network grnet
+2026-05-27 14:24:09.981 [GR] start node ps1 (server-id=1, 33061->3306)
+2026-05-27 14:24:11.400 [GR] wait for ps1 to accept connections
+2026-05-27 14:24:30.210 [GR] bootstrap cluster on ps1
+2026-05-27 14:24:33.005 [GR] add ps2 to cluster (clone)
+2026-05-27 14:24:48.117 [GR] add ps3 to cluster (clone)
+2026-05-27 14:25:02.640 [GR] cluster is ONLINE
+2026-05-27 14:25:02.900 [GR] verify GR variables on each node
+2026-05-27 14:25:03.330 [GR] create database gr_test
+2026-05-27 14:25:03.560 [GR] create table gr_test.t
+2026-05-27 14:25:03.770 [GR] insert 3 rows into gr_test.t
+2026-05-27 14:25:04.010 [GR] compare checksum gr_test.t across nodes
+2026-05-27 14:25:05.220 [GR] destroy cluster
+```
+
+Tests can narrate their own steps the same way by calling `gr_cluster.log("...")`
+— it shares the `[GR]` prefix and obeys the same `GR_VERBOSE` toggle (see the
+`gr_cluster.log(...)` calls in `test_basic.py`).
+
+When constructing the cluster directly you can also pass `verbose=True`:
+
+```python
+cluster = GroupReplication(helper, num_nodes=3, verbose=True)
+```
+
+Outside pytest (e.g. a standalone script), configure logging so the messages
+show: `logging.basicConfig(level=logging.INFO)`.
+
 ### Timeouts
 
 `pytest-timeout` is installed. To cap a single run:

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -7,12 +7,14 @@ in containers (Percona Server 8.4) and runs tests against it.
 
 ```
 group-replication/
-├── conftest.py              # gr_cluster fixture (module-scoped)
+├── conftest.py              # gr_cluster + sysbench fixtures
 ├── pytest.ini               # python_files = test_*.py
 ├── requirements.txt         # pytest, pytest-timeout
 ├── docker_helper.py         # DockerHelper — wraps docker/podman CLI
 ├── group_replication.py     # GroupReplication — N-node cluster lifecycle
+├── sysbench_helper.py       # Sysbench — ephemeral sysbench load container
 ├── test_basic.py            # smoke test: write on primary, read on every node
+├── test_failover.py         # primary failover + recovery under sysbench load
 └── templates/
     └── docker-compose.yaml  # equivalent 3-node topology, for reference
 ```
@@ -40,6 +42,35 @@ cd /Users/plavi/Development/percona/server-qa/test_scripts/ps/group-replication
 The fixture brings up 3 containers (`ps1`, `ps2`, `ps3`) on the `grnet` network,
 bootstraps the cluster via mysqlsh, runs the tests, then removes containers,
 volumes, and the network. Expect ~1 minute end-to-end.
+
+## Failover test (sysbench)
+
+`test_failover.py` drives real load and exercises a primary outage:
+
+```bash
+GR_VERBOSE=1 /Users/plavi/Development/percona/server-qa/.venv/bin/pytest -v test_failover.py
+```
+
+What it does: load initial data with sysbench (`prepare`, 4 tables × 10000 rows),
+stop the primary and assert a secondary is promoted, run a 20s `oltp_read_write`
+workload against the new primary and compare checksums across the online nodes,
+restart the stopped node (it **auto-rejoins** because the framework persists
+`group_replication_start_on_boot=ON`), then run another 20s workload against the
+full cluster and compare checksums across all three. Expect ~2-3 minutes.
+
+Sysbench notes:
+- Runs from the multi-arch image `pingwinator/sysbench:latest` (pulled on first
+  use). Each sysbench command is its own one-shot `--rm` container named
+  `sysbench_<test-name>` on `grnet` — nothing persists between calls.
+- The `sysbench` fixture creates the `sbtest` database and a `sysbench`@`'%'`
+  MySQL user on the primary (replicated cluster-wide, so it survives failover).
+- sysbench always targets the **current** primary (single-primary mode only
+  accepts writes on the primary); the framework resolves it dynamically via
+  `gr_cluster.get_primary()`.
+
+Relevant `GroupReplication` helpers: `get_primary()`, `stop_node()`,
+`rejoin_node()`, `wait_all_online()`, and `verify_checksums(database, nodes=...)`
+(defaults to the currently-online nodes).
 
 ## Options
 

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -40,9 +40,9 @@ cd test_scripts/ps/group-replication
 pytest -v test_basic.py
 ```
 
-The fixture brings up 3 containers (`ps1`, `ps2`, `ps3`) on the `grnet` network,
-bootstraps the cluster via mysqlsh, runs the tests, then removes containers,
-volumes, and the network. Expect ~1 minute end-to-end.
+The fixture brings up 3 containers (by default `ps0-1`, `ps0-2`, `ps0-3`) on a per-worker
+`grnet-<workerid>` network (e.g. `grnet-master`), bootstraps the cluster via mysqlsh, runs the tests,
+then removes containers, volumes, and the network. Expect ~1 minute end-to-end.
 
 ## Failover test (sysbench)
 
@@ -426,9 +426,9 @@ If a previous run aborted before the fixture's teardown, you'll have leftover
 containers/network/volumes. Clean them up:
 
 ```bash
-docker rm -f ps1 ps2 ps3 psrouter pshaproxy
-docker volume rm ps1-data ps2-data ps3-data
-docker network rm grnet
+docker rm -f <node_prefix>1 <node_prefix>2 <node_prefix>3 <node_prefix>router <node_prefix>haproxy
+docker volume rm <node_prefix>1-data <node_prefix>2-data <node_prefix>3-data
+docker network rm grnet-<workerid>
 ```
 
 ## Writing more tests

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -76,7 +76,7 @@ Relevant `GroupReplication` helpers: `get_primary()`, `stop_node()`,
 
 ## Scaling test (sysbench)
 
-`test_scaling.py` exercises elastic membership changes under load:
+`test_scaling.py` exercises elastic membership changes and data consistency checks, with a workload phase between scale operations:
 
 ```bash
 GR_VERBOSE=1 pytest -v test_scaling.py

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -248,6 +248,24 @@ CONTAINER_CLI=podman pytest -v test_basic.py
 > only have podman installed under that alias, set `CONTAINER_CLI=podman`
 > explicitly.
 
+### Overriding container images
+
+Each component's image can be overridden via an environment variable; if unset, the
+default below is used. Useful for testing a release candidate, a custom tag, or an
+internal registry mirror without editing code.
+
+| Env var            | Component      | Default image                       |
+|--------------------|----------------|-------------------------------------|
+| `SERVER_IMAGE`     | Percona Server | `percona/percona-server:8.4`        |
+| `HAPROXY_IMAGE`    | HAProxy        | `percona/haproxy:2`                 |
+| `ROUTER_IMAGE`     | MySQL Router   | `percona/percona-mysql-router:8.4`  |
+| `XTRABACKUP_IMAGE` | XtraBackup     | `percona/percona-xtrabackup:8.4`    |
+| `SYSBENCH_IMAGE`   | sysbench       | `pingwinator/sysbench:latest`       |
+
+```bash
+SERVER_IMAGE=percona/percona-server:8.4.5 pytest -v test_basic.py
+```
+
 ### Output verbosity
 
 ```bash

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -73,44 +73,86 @@ Relevant `GroupReplication` helpers: `get_primary()`, `stop_node()`,
 `rejoin_node()`, `wait_all_online()`, and `verify_checksums(database, nodes=...)`
 (defaults to the currently-online nodes).
 
-## MySQL Router
+## Proxies (MySQL Router and HAProxy)
 
 Tests run **through a proxy**, selected by the parametrized `gr_cluster` fixture.
-Today the only proxy is **MySQL Router** (`mysql_router=True`), so every test gets
-a `[router]` id suffix (e.g. `test_basic.py::test_replicates_table_across_nodes[router]`).
-HAProxy will be added as a second parametrized mode later; there is intentionally
-no "direct" mode in the test matrix (the `GroupReplication` class still defaults to
-`mysql_router=False` for direct use outside the suite).
+Two modes are exercised — **MySQL Router** (`mysql_router=True`) and **HAProxy**
+(`haproxy=True`) — so by default every test runs twice, with `[router]` and
+`[haproxy]` id suffixes (e.g. `test_replicates_table_across_nodes[router]` and
+`[haproxy]`). There is intentionally no "direct" mode in the matrix (the
+`GroupReplication` class still defaults to no proxy for direct use outside the
+suite). `create()` starts the proxy on the cluster network **after** the InnoDB
+Cluster is ONLINE.
 
-When `mysql_router=True`, `create()` starts a `percona/percona-mysql-router:8.4`
-container named `psrouter` on the cluster network **after** the InnoDB Cluster is
-ONLINE, bootstrapping it against a live member. The router exposes:
+### Restricting a test to a subset of proxies
+
+Unmarked tests run under all proxies. To pin a test to a subset, use the
+`proxies` marker:
+
+```python
+@pytest.mark.proxies("haproxy")          # haproxy only
+def test_haproxy_specific(gr_cluster): ...
+
+@pytest.mark.proxies("router")           # router only
+def test_router_specific(gr_cluster): ...
+
+def test_both(gr_cluster): ...           # default — runs under router AND haproxy
+```
+
+### MySQL Router (`psrouter`)
+
+Image `percona/percona-mysql-router:8.4`, bootstrapped against a live member. Exposes:
 
 - `6446` — classic read/write, routes to the **primary** (follows failover),
 - `6447` — classic read-only, load-balances across **secondaries**,
 - `6448`/`6449` — the same split over the X protocol.
 
-Host ports `33150` → `6446` and `33151` → `6447` are published for manual
-debugging (`mysql -h 127.0.0.1 -P 33150 -uroot -prootpass`).
+Host ports `33150` → `6446`, `33151` → `6447` (for manual debugging:
+`mysql -h 127.0.0.1 -P 33150 -uroot -prootpass`).
 
-**What routes through the router and what stays direct.** The router is only a
-client connection path for **application traffic** — test DDL/DML and sysbench
-go through `6446`. The control plane stays **direct, per-node** and never goes
-through the router: the mysqlsh cluster bootstrap, `SET PERSIST`, `get_primary()`,
-membership/state polling, per-node variable checks in `verify()`, and per-node
-`verify_checksums()` — these inspect or configure individual members, which a
-proxy that routes to a single node cannot do.
+### HAProxy (`pshaproxy`)
+
+Image `perconalab/percona-server-mysql-operator:main-haproxy` (ships `haproxy` +
+a MySQL client, amd64-only — pulled with `--platform linux/amd64`). Two frontends:
+
+- `3307` — read/write, `balance first` → the current **primary**,
+- `3308` — read-only, `balance roundrobin` across live members.
+
+HAProxy is not SQL-aware and can't tell which member is the primary. Both backends
+use the built-in `mysql-check` only for **liveness**; the framework then pins the
+write backend to the current primary via HAProxy's **runtime API** over the stats
+socket (`set server be_write/<node> state ready|maint`) — the same external-management
+model the Percona operator uses. On failover, `wait_proxy_ready()` re-pins the write
+backend to the newly elected primary. (An autonomous `external-check` script keyed on
+`super_read_only` was tried first but is pathologically slow under the amd64-on-arm64
+**emulation** this image runs in, where each forked check can stall for minutes.)
+
+Host ports `33152` → `3307`, `33153` → `3308`. The config is injected via an
+environment variable (no host bind mounts), and the container runs as the image's
+non-root `mysql` user.
+
+### What routes through the proxy and what stays direct
+
+The proxy is only a client connection path for **application traffic** — test
+DDL/DML and sysbench go through the read/write endpoint. The control plane stays
+**direct, per-node** and never goes through the proxy: the mysqlsh cluster
+bootstrap, `SET PERSIST`, `get_primary()`, membership/state polling, per-node
+variable checks in `verify()`, and per-node `verify_checksums()` — these inspect
+or configure individual members, which a proxy that routes to a single node cannot do.
 
 Proxy-agnostic accessors on `GroupReplication` keep tests identical across proxies:
 
-- `rw_endpoint()` → `(host, port)` for read/write traffic (router `6446` when
-  enabled, else the live primary on `3306`).
-- `ro_endpoint()` → `(host, port)` for read-only traffic (router `6447` when
-  enabled, else an active secondary on `3306`).
+- `rw_endpoint()` → `(host, port)` for read/write traffic (the proxy's write
+  endpoint when enabled, else the live primary on `3306`).
+- `ro_endpoint()` → `(host, port)` for read-only traffic (the proxy's read
+  endpoint when enabled, else an active secondary on `3306`).
 - `exec_sql(sql, database=None)` — run application SQL through the read/write
-  endpoint (routed via the router when enabled, else direct to the primary).
-- `verify(check_router=...)` — defaults to checking, when the router is enabled,
-  that the RW endpoint routes to the current primary.
+  endpoint (routed via the proxy when enabled, else direct to the primary).
+- `wait_proxy_ready()` — block until the proxy's RW endpoint routes to the current
+  primary (used after failover before resuming writes).
+- `verify(check_proxy=...)` — defaults to checking, when a proxy is enabled, that
+  the RW endpoint routes to the current primary.
+- `gr_cluster.proxy` — `"router"`, `"haproxy"`, or `None`.
 
 ## Options
 
@@ -307,7 +349,7 @@ If a previous run aborted before the fixture's teardown, you'll have leftover
 containers/network/volumes. Clean them up:
 
 ```bash
-docker rm -f ps1 ps2 ps3 psrouter
+docker rm -f ps1 ps2 ps3 psrouter pshaproxy
 docker volume rm ps1-data ps2-data ps3-data
 docker network rm grnet
 ```

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -63,14 +63,54 @@ Sysbench notes:
   use). Each sysbench command is its own one-shot `--rm` container named
   `sysbench_<test-name>` on `grnet` — nothing persists between calls.
 - The `sysbench` fixture creates the `sbtest` database and a `sysbench`@`'%'`
-  MySQL user on the primary (replicated cluster-wide, so it survives failover).
-- sysbench always targets the **current** primary (single-primary mode only
-  accepts writes on the primary); the framework resolves it dynamically via
-  `gr_cluster.get_primary()`.
+  MySQL user (replicated cluster-wide, so it survives failover).
+- sysbench targets the cluster's **read/write endpoint**, resolved dynamically
+  via `gr_cluster.rw_endpoint()` — the MySQL Router RW port when the router is
+  enabled (it routes writes to the current primary and follows failover), or the
+  current primary directly otherwise.
 
 Relevant `GroupReplication` helpers: `get_primary()`, `stop_node()`,
 `rejoin_node()`, `wait_all_online()`, and `verify_checksums(database, nodes=...)`
 (defaults to the currently-online nodes).
+
+## MySQL Router
+
+Tests run **through a proxy**, selected by the parametrized `gr_cluster` fixture.
+Today the only proxy is **MySQL Router** (`mysql_router=True`), so every test gets
+a `[router]` id suffix (e.g. `test_basic.py::test_replicates_table_across_nodes[router]`).
+HAProxy will be added as a second parametrized mode later; there is intentionally
+no "direct" mode in the test matrix (the `GroupReplication` class still defaults to
+`mysql_router=False` for direct use outside the suite).
+
+When `mysql_router=True`, `create()` starts a `percona/percona-mysql-router:8.4`
+container named `psrouter` on the cluster network **after** the InnoDB Cluster is
+ONLINE, bootstrapping it against a live member. The router exposes:
+
+- `6446` — classic read/write, routes to the **primary** (follows failover),
+- `6447` — classic read-only, load-balances across **secondaries**,
+- `6448`/`6449` — the same split over the X protocol.
+
+Host ports `33150` → `6446` and `33151` → `6447` are published for manual
+debugging (`mysql -h 127.0.0.1 -P 33150 -uroot -prootpass`).
+
+**What routes through the router and what stays direct.** The router is only a
+client connection path for **application traffic** — test DDL/DML and sysbench
+go through `6446`. The control plane stays **direct, per-node** and never goes
+through the router: the mysqlsh cluster bootstrap, `SET PERSIST`, `get_primary()`,
+membership/state polling, per-node variable checks in `verify()`, and per-node
+`verify_checksums()` — these inspect or configure individual members, which a
+proxy that routes to a single node cannot do.
+
+Proxy-agnostic accessors on `GroupReplication` keep tests identical across proxies:
+
+- `rw_endpoint()` → `(host, port)` for read/write traffic (router `6446` when
+  enabled, else the live primary on `3306`).
+- `ro_endpoint()` → `(host, port)` for read-only traffic (router `6447` when
+  enabled, else an active secondary on `3306`).
+- `exec_sql(sql, database=None)` — run application SQL through the read/write
+  endpoint (routed via the router when enabled, else direct to the primary).
+- `verify(check_router=...)` — defaults to checking, when the router is enabled,
+  that the RW endpoint routes to the current primary.
 
 ## Options
 
@@ -267,7 +307,7 @@ If a previous run aborted before the fixture's teardown, you'll have leftover
 containers/network/volumes. Clean them up:
 
 ```bash
-docker rm -f ps1 ps2 ps3
+docker rm -f ps1 ps2 ps3 psrouter
 docker volume rm ps1-data ps2-data ps3-data
 docker network rm grnet
 ```
@@ -277,6 +317,11 @@ docker network rm grnet
 Add files named `test_*.py` in this directory. Request the `gr_cluster`
 fixture and use:
 
+- `gr_cluster.exec_sql("SQL;")` — run application SQL through the read/write
+  endpoint (the router when enabled, else the primary). Use this for DDL/DML
+  instead of targeting a node directly, so the test is proxy-agnostic.
+- `gr_cluster.rw_endpoint()` / `gr_cluster.ro_endpoint()` — `(host, port)` for
+  read/write or read-only client traffic (e.g. to point sysbench at).
 - `gr_cluster.primary()` — name of the bootstrap node (`"ps1"`).
 - `gr_cluster.containers` — list of all node names in start order.
 - `gr_cluster.docker` — the `DockerHelper`. Common methods:

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -287,9 +287,9 @@ timestamped to help debug timing/hangs):
 
 ```
 2026-05-27 14:24:09.512 [GR] create network grnet
-2026-05-27 14:24:09.981 [GR] start node ps1 (server-id=1, 33061->3306)
-2026-05-27 14:24:11.400 [GR] wait for ps1 to accept connections
-2026-05-27 14:24:30.210 [GR] bootstrap cluster on ps1
+2026-05-27 14:24:09.981 [GR] start node ps0-1 (server-id=1, 33061->3306)
+2026-05-27 14:24:11.400 [GR] wait for ps0-1 to accept connections
+2026-05-27 14:24:30.210 [GR] bootstrap cluster on ps0-1
 2026-05-27 14:24:33.005 [GR] add ps2 to cluster (clone)
 2026-05-27 14:24:48.117 [GR] add ps3 to cluster (clone)
 2026-05-27 14:25:02.640 [GR] cluster is ONLINE
@@ -386,24 +386,24 @@ terminal and use `docker exec`:
 
 ```bash
 # Cluster status
-docker exec ps1 mysqlsh --uri root:rootpass@localhost:3306 --js -e "print(dba.getCluster().status())"
+docker exec ps0-1 mysqlsh --uri root:rootpass@localhost:3306 --js -e "print(dba.getCluster().status())"
 
 # Quick SQL on the primary
-docker exec ps1 mysql -uroot -prootpass -e "SELECT @@hostname, @@server_id;"
+docker exec ps0-1 mysql -uroot -prootpass -e "SELECT @@hostname, @@server_id;"
 
 # Same on a replica
-docker exec ps2 mysql -uroot -prootpass -e "SELECT * FROM performance_schema.replication_group_members;"
+docker exec ps0-2 mysql -uroot -prootpass -e "SELECT * FROM performance_schema.replication_group_members;"
 
 # Interactive mysqlsh session
-docker exec -it ps1 mysqlsh --uri root:rootpass@localhost:3306
+docker exec -it ps0-1 mysqlsh --uri root:rootpass@localhost:3306
 
 # Tail mysqld error log
-docker logs -f ps1
+docker logs -f ps0-1
 ```
 
 ### Connect from the host
 
-The fixture publishes host ports `33061` (ps1), `33062` (ps2), `33063` (ps3) →
+The fixture publishes host ports `33061` (ps0-1), `33062` (ps0-2), `33063` (ps0-3) →
 container `3306`. So while the cluster is up:
 
 ```bash
@@ -441,7 +441,7 @@ fixture and use:
   instead of targeting a node directly, so the test is proxy-agnostic.
 - `gr_cluster.rw_endpoint()` / `gr_cluster.ro_endpoint()` — `(host, port)` for
   read/write or read-only client traffic (e.g. to point sysbench at).
-- `gr_cluster.primary()` — name of the bootstrap node (`"ps1"`).
+- `gr_cluster.primary()` — name of the bootstrap node (`"ps0-1"`).
 - `gr_cluster.containers` — list of all node names in start order.
 - `gr_cluster.docker` — the `DockerHelper`. Common methods:
   - `docker.exec_mysql(node, "SQL;", database=None)` → returns `ExecResult` with `.stdout`, `.stderr`, `.returncode`, `.ok`.

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -102,7 +102,7 @@ with Percona XtraBackup. It runs **behind HAProxy only** (the proxy is irrelevan
 backup/restore):
 
 ```bash
-GR_VERBOSE=1 /Users/plavi/Development/percona/server-qa/.venv/bin/pytest -v test_backup_restore.py
+GR_VERBOSE=1 pytest -v test_backup_restore.py
 ```
 
 What it does: load data with sysbench, take a **full** backup of a secondary

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -7,19 +7,17 @@ in containers (Percona Server 8.4) and runs tests against it.
 
 ```
 group-replication/
-├── conftest.py              # gr_cluster + sysbench fixtures
-├── pytest.ini               # python_files = test_*.py
-├── requirements.txt         # pytest, pytest-timeout
-├── docker_helper.py         # DockerHelper — wraps docker/podman CLI
-├── group_replication.py     # GroupReplication — N-node cluster lifecycle
-├── sysbench_helper.py       # Sysbench — ephemeral sysbench load container
-├── xtrabackup_helper.py     # XtraBackup — full/incremental backup + restore
-├── test_basic.py            # smoke test: write on primary, read on every node
-├── test_failover.py         # primary failover + recovery under sysbench load
-├── test_scaling.py          # scale up 3->5 and down 5->3 under sysbench load
-├── test_backup_restore.py   # XtraBackup full+incremental backup and restore
-└── templates/
-    └── docker-compose.yaml  # equivalent 3-node topology, for reference
+├── conftest.py                 # gr_cluster + sysbench + xtrabackup fixtures
+├── pytest.ini                  # python_files = test_*.py
+├── requirements.txt            # pytest, pytest-timeout
+├── docker_helper.py            # DockerHelper — wraps docker/podman CLI
+├── group_replication_helper.py # GroupReplication — N-node cluster lifecycle
+├── sysbench_helper.py          # Sysbench — ephemeral sysbench load container
+├── xtrabackup_helper.py        # XtraBackup — full/incremental backup + restore
+├── test_basic.py               # smoke test: write on primary, read on every node
+├── test_failover.py            # primary failover + recovery under sysbench load
+├── test_scaling.py             # scale up 3->5 and down 5->3 under sysbench load
+└── test_backup_restore.py      # XtraBackup full+incremental backup and restore
 ```
 
 ## Prerequisites
@@ -176,8 +174,7 @@ Host ports `33150` → `6446`, `33151` → `6447` (for manual debugging:
 
 ### HAProxy (`pshaproxy`)
 
-Image `perconalab/percona-server-mysql-operator:main-haproxy` (ships `haproxy` +
-a MySQL client, amd64-only — pulled with `--platform linux/amd64`). Two frontends:
+Image `percona/haproxy:2`. Two frontends:
 
 - `3307` — read/write, `balance first` → the current **primary**,
 - `3308` — read-only, `balance roundrobin` across live members.
@@ -187,9 +184,7 @@ use the built-in `mysql-check` only for **liveness**; the framework then pins th
 write backend to the current primary via HAProxy's **runtime API** over the stats
 socket (`set server be_write/<node> state ready|maint`) — the same external-management
 model the Percona operator uses. On failover, `wait_proxy_ready()` re-pins the write
-backend to the newly elected primary. (An autonomous `external-check` script keyed on
-`super_read_only` was tried first but is pathologically slow under the amd64-on-arm64
-**emulation** this image runs in, where each forked check can stall for minutes.)
+backend to the newly elected primary.
 
 Host ports `33152` → `3307`, `33153` → `3308`. The config is injected via an
 environment variable (no host bind mounts), and the container runs as the image's

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -11,6 +11,7 @@ group-replication/
 ├── pytest.ini                  # python_files = test_*.py
 ├── requirements.txt            # pytest, pytest-timeout
 ├── docker_helper.py            # DockerHelper — wraps docker/podman CLI
+├── generic_helper.py           # shared SQL/JS string-escaping helpers
 ├── group_replication_helper.py # GroupReplication — N-node cluster lifecycle
 ├── sysbench_helper.py          # Sysbench — ephemeral sysbench load container
 ├── xtrabackup_helper.py        # XtraBackup — full/incremental backup + restore

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -26,9 +26,9 @@ group-replication/
   back to `podman` if `docker` isn't installed). Make sure the Docker daemon
   is running.
 - The `percona/percona-server:8.4` image. First run will pull it automatically.
-- Python venv with `pytest` and `pytest-timeout`:
+- Python 3.10+ venv with `pytest` and `pytest-timeout`:
   ```bash
-  /Users/plavi/Development/percona/server-qa/.venv/bin/pip install -r requirements.txt
+  python -m pip install -r requirements.txt
   ```
 
 ## Running the test

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -1,0 +1,223 @@
+# MySQL Group Replication — pytest framework
+
+A small pytest framework that brings up an N-node MySQL Group Replication cluster
+in containers (Percona Server 8.4) and runs tests against it.
+
+## Layout
+
+```
+group-replication/
+├── conftest.py              # gr_cluster fixture (module-scoped)
+├── pytest.ini               # python_files = test_*.py
+├── requirements.txt         # pytest, pytest-timeout
+├── docker_helper.py         # DockerHelper — wraps docker/podman CLI
+├── group_replication.py     # GroupReplication — N-node cluster lifecycle
+├── test_basic.py            # smoke test: write on primary, read on every node
+└── templates/
+    └── docker-compose.yaml  # equivalent 3-node topology, for reference
+```
+
+## Prerequisites
+
+- `docker` in `$PATH` (the framework auto-detects `docker` first, then falls
+  back to `podman` if `docker` isn't installed). Make sure the Docker daemon
+  is running.
+- The `percona/percona-server:8.4` image. First run will pull it automatically.
+- Python venv with `pytest` and `pytest-timeout`:
+  ```bash
+  /Users/plavi/Development/percona/server-qa/.venv/bin/pip install -r requirements.txt
+  ```
+
+## Running the test
+
+From the `group-replication/` directory:
+
+```bash
+cd /Users/plavi/Development/percona/server-qa/test_scripts/ps/group-replication
+/Users/plavi/Development/percona/server-qa/.venv/bin/pytest -v test_basic.py
+```
+
+The fixture brings up 3 containers (`ps1`, `ps2`, `ps3`) on the `grnet` network,
+bootstraps the cluster via mysqlsh, runs the tests, then removes containers,
+volumes, and the network. Expect ~1 minute end-to-end.
+
+## Options
+
+### Test selection
+
+```bash
+# A single test by id
+pytest -v test_basic.py::test_replicates_table_across_nodes
+
+# All tests matching a substring
+pytest -v -k replicates
+
+# Only tests marked @pytest.mark.smoke (when you add markers)
+pytest -v -m smoke
+```
+
+### Container runtime
+
+The framework auto-detects `docker` first, then `podman`, via `shutil.which`.
+Override with the `CONTAINER_CLI` env var:
+
+```bash
+CONTAINER_CLI=docker pytest -v test_basic.py
+CONTAINER_CLI=podman pytest -v test_basic.py
+```
+
+> Note: a shell alias such as `docker=podman` does **not** propagate to
+> subprocess — the framework looks for an actual binary on `$PATH`. If you
+> only have podman installed under that alias, set `CONTAINER_CLI=podman`
+> explicitly.
+
+### Output verbosity
+
+```bash
+pytest -v test_basic.py        # default — verbose
+pytest -vv test_basic.py       # extra-verbose: full assertion diffs
+pytest -s test_basic.py        # don't capture stdout/stderr (live container logs)
+pytest --tb=short test_basic.py  # shorter tracebacks
+```
+
+### Timeouts
+
+`pytest-timeout` is installed. To cap a single run:
+
+```bash
+pytest --timeout=300 test_basic.py
+```
+
+Or add `@pytest.mark.timeout(300)` to individual tests.
+
+### Cluster size and other knobs
+
+The default fixture creates 3 nodes. To customize per-test, write your own
+fixture using the framework classes directly:
+
+```python
+@pytest.fixture(scope="module")
+def big_cluster():
+    helper = DockerHelper()
+    cluster = GroupReplication(
+        helper,
+        num_nodes=5,
+        network="bignet",
+        node_prefix="big",
+        base_host_port=33070,        # → host ports 33071..33075
+        cluster_name="bigCluster",
+        mysql_extra_args=["--innodb-buffer-pool-size=256M"],
+    )
+    cluster.create()
+    try:
+        yield cluster
+    finally:
+        cluster.destroy(remove_volumes=True)
+```
+
+## Debugging
+
+### Drop into pdb on failure
+
+```bash
+pytest -v --pdb test_basic.py
+```
+
+pytest will pause at the failing assertion. Useful commands inside pdb:
+`l` (list code), `p <expr>` (print), `c` (continue), `q` (quit).
+
+### Pause with `breakpoint()` mid-test
+
+Insert `breakpoint()` anywhere in the test or in `conftest.py` to stop there:
+
+```python
+def test_replicates_table_across_nodes(gr_cluster):
+    primary = gr_cluster.primary()
+    docker = gr_cluster.docker
+    breakpoint()       # <-- stops here; cluster is fully up
+    docker.exec_mysql(primary, "CREATE DATABASE IF NOT EXISTS gr_test;")
+```
+
+For the breakpoint prompt to be interactive you must disable pytest's output
+capture:
+
+```bash
+pytest -v -s test_basic.py
+```
+
+### Inspect a live cluster from another shell
+
+While paused at a `breakpoint()` (or while the fixture is up), open another
+terminal and use `docker exec`:
+
+```bash
+# Cluster status
+docker exec ps1 mysqlsh --uri root:rootpass@localhost:3306 --js -e "print(dba.getCluster().status())"
+
+# Quick SQL on the primary
+docker exec ps1 mysql -uroot -prootpass -e "SELECT @@hostname, @@server_id;"
+
+# Same on a replica
+docker exec ps2 mysql -uroot -prootpass -e "SELECT * FROM performance_schema.replication_group_members;"
+
+# Interactive mysqlsh session
+docker exec -it ps1 mysqlsh --uri root:rootpass@localhost:3306
+
+# Tail mysqld error log
+docker logs -f ps1
+```
+
+### Connect from the host
+
+The fixture publishes host ports `33061` (ps1), `33062` (ps2), `33063` (ps3) →
+container `3306`. So while the cluster is up:
+
+```bash
+mysql -h 127.0.0.1 -P 33061 -uroot -prootpass
+mysqlsh --uri root:rootpass@127.0.0.1:33061
+```
+
+(Useful with GUI clients too: MySQL Workbench, DBeaver, TablePlus.)
+
+### Keep the cluster up after a test
+
+The easiest way is to keep `breakpoint()` paused — the fixture only tears
+down once the test returns. Alternatively, comment out the
+`cluster.destroy(remove_volumes=True)` line in `conftest.py` for a one-off
+manual session, then clean up yourself (see below).
+
+### Re-run after a crashed setup
+
+If a previous run aborted before the fixture's teardown, you'll have leftover
+containers/network/volumes. Clean them up:
+
+```bash
+docker rm -f ps1 ps2 ps3
+docker volume rm ps1-data ps2-data ps3-data
+docker network rm grnet
+```
+
+## Writing more tests
+
+Add files named `test_*.py` in this directory. Request the `gr_cluster`
+fixture and use:
+
+- `gr_cluster.primary()` — name of the bootstrap node (`"ps1"`).
+- `gr_cluster.containers` — list of all node names in start order.
+- `gr_cluster.docker` — the `DockerHelper`. Common methods:
+  - `docker.exec_mysql(node, "SQL;", database=None)` → returns `ExecResult` with `.stdout`, `.stderr`, `.returncode`, `.ok`.
+  - `docker.exec_mysqlsh(node, "<JS script>")` — same return shape, runs mysqlsh AdminAPI.
+  - `docker.exec_command(node, "shell command")` — arbitrary `sh -c` inside the container.
+  - `docker.stop(node)` / `docker.start(node)` — useful for failover-style tests.
+
+Skeleton:
+
+```python
+def test_my_thing(gr_cluster):
+    primary = gr_cluster.primary()
+    docker = gr_cluster.docker
+    docker.exec_mysql(primary, "CREATE DATABASE demo;")
+    for node in gr_cluster.containers:
+        result = docker.exec_mysql(node, "SHOW DATABASES LIKE 'demo';")
+        assert "demo" in result.stdout
+```

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -190,12 +190,12 @@ Image `percona/haproxy:2`. Two frontends:
 - `3307` — read/write, `balance first` → the current **primary**,
 - `3308` — read-only, `balance roundrobin` across live members.
 
-HAProxy is not SQL-aware and can't tell which member is the primary. Both backends
-use the built-in `mysql-check` only for **liveness**; the framework then pins the
-write backend to the current primary via HAProxy's **runtime API** over the stats
-socket (`set server be_write/<node> state ready|maint`) — the same external-management
-model the Percona operator uses. On failover, `wait_proxy_ready()` re-pins the write
-backend to the newly elected primary.
+HAProxy is not SQL-aware and can't tell which member is the primary. Health checks are
+just a plain TCP-connect **liveness** probe (enabled cluster-wide via `default-server
+check`); the framework then pins the write backend to the current primary via HAProxy's
+**runtime API** over the stats socket (`set server be_write/<node> state ready|maint`) —
+the same external-management model the Percona operator uses. On failover,
+`wait_proxy_ready()` re-pins the write backend to the newly elected primary.
 
 Host ports `33152` → `3307`, `33153` → `3308`. The config is injected via an
 environment variable (no host bind mounts), and the container runs as the image's

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -62,7 +62,7 @@ full cluster and compare checksums across all three. Expect ~2-3 minutes.
 Sysbench notes:
 - Runs from the multi-arch image `pingwinator/sysbench:latest` (pulled on first
   use). Each sysbench command is its own one-shot `--rm` container named
-  `sysbench_<test-name>` on `grnet` — nothing persists between calls.
+  `sysbench_<workerid>_<test-name>` on `grnet-<workerid>` — nothing persists between calls.
 - The `sysbench` fixture creates the `sbtest` database and a `sysbench`@`'%'`
   MySQL user (replicated cluster-wide, so it survives failover).
 - sysbench targets the cluster's **read/write endpoint**, resolved dynamically

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -15,6 +15,7 @@ group-replication/
 ├── sysbench_helper.py       # Sysbench — ephemeral sysbench load container
 ├── test_basic.py            # smoke test: write on primary, read on every node
 ├── test_failover.py         # primary failover + recovery under sysbench load
+├── test_scaling.py          # scale up 3->5 and down 5->3 under sysbench load
 └── templates/
     └── docker-compose.yaml  # equivalent 3-node topology, for reference
 ```
@@ -72,6 +73,27 @@ Sysbench notes:
 Relevant `GroupReplication` helpers: `get_primary()`, `stop_node()`,
 `rejoin_node()`, `wait_all_online()`, and `verify_checksums(database, nodes=...)`
 (defaults to the currently-online nodes).
+
+## Scaling test (sysbench)
+
+`test_scaling.py` exercises elastic membership changes under load:
+
+```bash
+GR_VERBOSE=1 /Users/plavi/Development/percona/server-qa/.venv/bin/pytest -v test_scaling.py
+```
+
+What it does: load initial data with sysbench, **scale up** the cluster from 3 to 5
+nodes (`scale_up(2)` — each new node is started, `addInstance`'d with clone recovery,
+and waited ONLINE), verify checksums and cluster configuration across all five nodes,
+run a 20s `oltp_read_write` workload, then **scale down** back to 3 (`scale_down(2)` —
+removes the most recently added secondaries via `removeInstance`, never the primary,
+and destroys their containers/volumes) and re-verify. Expect ~3-4 minutes.
+
+Relevant `GroupReplication` helpers: `scale_up(count)`, `scale_down(count)`,
+`verify()`, and `verify_checksums()`. New nodes are named `ps4`, `ps5`, … and the
+proxy is reconciled automatically after each change — MySQL Router auto-discovers
+members from cluster metadata; HAProxy's container is recreated so its static backend
+server list matches the new membership (`_refresh_proxy()`).
 
 ## Proxies (MySQL Router and HAProxy)
 

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -36,8 +36,8 @@ group-replication/
 From the `group-replication/` directory:
 
 ```bash
-cd /Users/plavi/Development/percona/server-qa/test_scripts/ps/group-replication
-/Users/plavi/Development/percona/server-qa/.venv/bin/pytest -v test_basic.py
+cd test_scripts/ps/group-replication
+pytest -v test_basic.py
 ```
 
 The fixture brings up 3 containers (`ps1`, `ps2`, `ps3`) on the `grnet` network,

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -162,7 +162,11 @@ def test_haproxy_specific(gr_cluster): ...
 def test_router_specific(gr_cluster): ...
 ```
 
-### MySQL Router (`psrouter`)
+### MySQL Router (`<node_prefix>router`)
+
+The container name is derived from `node_prefix` (e.g. `ps0-router` with the default
+fixture, `psrouter` for a class constructed with the default `node_prefix="ps"`).
+
 
 Image `percona/percona-mysql-router:8.4`, bootstrapped against a live member. Exposes:
 
@@ -173,7 +177,11 @@ Image `percona/percona-mysql-router:8.4`, bootstrapped against a live member. Ex
 Host ports `33150` → `6446`, `33151` → `6447` (for manual debugging:
 `mysql -h 127.0.0.1 -P 33150 -uroot -prootpass`).
 
-### HAProxy (`pshaproxy`)
+### HAProxy (`<node_prefix>haproxy`)
+
+The container name is derived from `node_prefix` (e.g. `ps0-haproxy` with the default
+fixture, `pshaproxy` for a class constructed with the default `node_prefix="ps"`).
+
 
 Image `percona/haproxy:2`. Two frontends:
 
@@ -287,12 +295,12 @@ Sample output (appears in pytest's live log — no `-s` needed; each line is
 timestamped to help debug timing/hangs):
 
 ```
-2026-05-27 14:24:09.512 [GR] create network grnet
+2026-05-27 14:24:09.512 [GR] create network grnet-0
 2026-05-27 14:24:09.981 [GR] start node ps0-1 (server-id=1, 33061->3306)
 2026-05-27 14:24:11.400 [GR] wait for ps0-1 to accept connections
 2026-05-27 14:24:30.210 [GR] bootstrap cluster on ps0-1
-2026-05-27 14:24:33.005 [GR] add ps2 to cluster (clone)
-2026-05-27 14:24:48.117 [GR] add ps3 to cluster (clone)
+2026-05-27 14:24:33.005 [GR] add ps0-2 to cluster (clone)
+2026-05-27 14:24:48.117 [GR] add ps0-3 to cluster (clone)
 2026-05-27 14:25:02.640 [GR] cluster is ONLINE
 2026-05-27 14:25:02.900 [GR] verify GR variables on each node
 2026-05-27 14:25:03.330 [GR] create database gr_test

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -75,28 +75,33 @@ Relevant `GroupReplication` helpers: `get_primary()`, `stop_node()`,
 
 ## Proxies (MySQL Router and HAProxy)
 
-Tests run **through a proxy**, selected by the parametrized `gr_cluster` fixture.
-Two modes are exercised — **MySQL Router** (`mysql_router=True`) and **HAProxy**
-(`haproxy=True`) — so by default every test runs twice, with `[router]` and
-`[haproxy]` id suffixes (e.g. `test_replicates_table_across_nodes[router]` and
-`[haproxy]`). There is intentionally no "direct" mode in the matrix (the
-`GroupReplication` class still defaults to no proxy for direct use outside the
-suite). `create()` starts the proxy on the cluster network **after** the InnoDB
-Cluster is ONLINE.
+Tests run **through a proxy**, chosen per test with an explicit
+`@pytest.mark.parametrize("gr_cluster", [...], indirect=True)` so the proxy set is
+visible right above the test. Two modes are available — **MySQL Router**
+(`"router"`, `mysql_router=True`) and **HAProxy** (`"haproxy"`, `haproxy=True`) —
+each yielding a `[router]` / `[haproxy]` id suffix (e.g.
+`test_replicates_table_across_nodes[router]`). There is intentionally no "direct"
+mode (the `GroupReplication` class still defaults to no proxy for direct use outside
+the suite). `create()` starts the proxy on the cluster network **after** the InnoDB
+Cluster is ONLINE. The parametrize value is looked up in `PROXIES` in `conftest.py`.
 
-### Restricting a test to a subset of proxies
+### Choosing which proxies a test runs under
 
-Unmarked tests run under all proxies. To pin a test to a subset, use the
-`proxies` marker:
+Declare it explicitly on each test (no hidden default — a test without the decorator
+gets no `gr_cluster` parameter and fails fast):
 
 ```python
-@pytest.mark.proxies("haproxy")          # haproxy only
+# Runs under both proxies
+@pytest.mark.parametrize("gr_cluster", ["router", "haproxy"], indirect=True)
+def test_both(gr_cluster): ...
+
+# HAProxy only
+@pytest.mark.parametrize("gr_cluster", ["haproxy"], indirect=True)
 def test_haproxy_specific(gr_cluster): ...
 
-@pytest.mark.proxies("router")           # router only
+# MySQL Router only
+@pytest.mark.parametrize("gr_cluster", ["router"], indirect=True)
 def test_router_specific(gr_cluster): ...
-
-def test_both(gr_cluster): ...           # default — runs under router AND haproxy
 ```
 
 ### MySQL Router (`psrouter`)

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -452,7 +452,7 @@ fixture and use:
   instead of targeting a node directly, so the test is proxy-agnostic.
 - `gr_cluster.rw_endpoint()` / `gr_cluster.ro_endpoint()` — `(host, port)` for
   read/write or read-only client traffic (e.g. to point sysbench at).
-- `gr_cluster.get_bootstrap_node()` — name of the bootstrap node (`"ps0-1"`); for the
+- `gr_cluster.get_bootstrap_node()` — name of the bootstrap node (e.g. `"ps0-1"` when running serially, or `"psgw0-1"` under pytest-xdist); for the
   currently-elected primary (which differs after failover) use `gr_cluster.get_primary()`.
 - `gr_cluster.containers` — list of all node names in start order.
 - `gr_cluster.docker` — the `DockerHelper`. Common methods:

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -49,7 +49,7 @@ volumes, and the network. Expect ~1 minute end-to-end.
 `test_failover.py` drives real load and exercises a primary outage:
 
 ```bash
-GR_VERBOSE=1 /Users/plavi/Development/percona/server-qa/.venv/bin/pytest -v test_failover.py
+GR_VERBOSE=1 pytest -v test_failover.py
 ```
 
 What it does: load initial data with sysbench (`prepare`, 4 tables × 10000 rows),

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -26,6 +26,7 @@ group-replication/
   back to `podman` if `docker` isn't installed). Make sure the Docker daemon
   is running.
 - The `percona/percona-server:8.4` image. First run will pull it automatically.
+- `mysqlsh` (MySQL Shell) must be available in the chosen `SERVER_IMAGE` (used via `docker exec` for AdminAPI bootstrap).
 - Python 3.10+ venv with `pytest` and `pytest-timeout`:
   ```bash
   python -m pip install -r requirements.txt

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -375,7 +375,7 @@ Insert `breakpoint()` anywhere in the test or in `conftest.py` to stop there:
 
 ```python
 def test_replicates_table_across_nodes(gr_cluster):
-    primary = gr_cluster.primary()
+    primary = gr_cluster.get_bootstrap_node()
     docker = gr_cluster.docker
     breakpoint()       # <-- stops here; cluster is fully up
     docker.exec_mysql(primary, "CREATE DATABASE IF NOT EXISTS gr_test;")
@@ -450,7 +450,8 @@ fixture and use:
   instead of targeting a node directly, so the test is proxy-agnostic.
 - `gr_cluster.rw_endpoint()` / `gr_cluster.ro_endpoint()` — `(host, port)` for
   read/write or read-only client traffic (e.g. to point sysbench at).
-- `gr_cluster.primary()` — name of the bootstrap node (`"ps0-1"`).
+- `gr_cluster.get_bootstrap_node()` — name of the bootstrap node (`"ps0-1"`); for the
+  currently-elected primary (which differs after failover) use `gr_cluster.get_primary()`.
 - `gr_cluster.containers` — list of all node names in start order.
 - `gr_cluster.docker` — the `DockerHelper`. Common methods:
   - `docker.exec_mysql(node, "SQL;", database=None)` → returns `ExecResult` with `.stdout`, `.stderr`, `.returncode`, `.ok`.
@@ -462,7 +463,7 @@ Skeleton:
 
 ```python
 def test_my_thing(gr_cluster):
-    primary = gr_cluster.primary()
+    primary = gr_cluster.get_bootstrap_node()
     docker = gr_cluster.docker
     docker.exec_mysql(primary, "CREATE DATABASE demo;")
     for node in gr_cluster.containers:

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -90,7 +90,8 @@ removes the most recently added secondaries via `removeInstance`, never the prim
 and destroys their containers/volumes) and re-verify. Expect ~3-4 minutes.
 
 Relevant `GroupReplication` helpers: `scale_up(count)`, `scale_down(count)`,
-`verify()`, and `verify_checksums()`. New nodes are named `ps4`, `ps5`, … and the
+`verify()`, and `verify_checksums()`. New nodes follow the same naming pattern as the
+original members (i.e. `<node_prefix><index>` — e.g. `ps0-4`, `ps0-5`, … with the default fixture).
 proxy is reconciled automatically after each change — MySQL Router auto-discovers
 members from cluster metadata; HAProxy's container is recreated so its static backend
 server list matches the new membership (`_refresh_proxy()`).

--- a/test_scripts/ps/group-replication/README.md
+++ b/test_scripts/ps/group-replication/README.md
@@ -13,9 +13,11 @@ group-replication/
 ├── docker_helper.py         # DockerHelper — wraps docker/podman CLI
 ├── group_replication.py     # GroupReplication — N-node cluster lifecycle
 ├── sysbench_helper.py       # Sysbench — ephemeral sysbench load container
+├── xtrabackup_helper.py     # XtraBackup — full/incremental backup + restore
 ├── test_basic.py            # smoke test: write on primary, read on every node
 ├── test_failover.py         # primary failover + recovery under sysbench load
 ├── test_scaling.py          # scale up 3->5 and down 5->3 under sysbench load
+├── test_backup_restore.py   # XtraBackup full+incremental backup and restore
 └── templates/
     └── docker-compose.yaml  # equivalent 3-node topology, for reference
 ```
@@ -94,6 +96,41 @@ Relevant `GroupReplication` helpers: `scale_up(count)`, `scale_down(count)`,
 proxy is reconciled automatically after each change — MySQL Router auto-discovers
 members from cluster metadata; HAProxy's container is recreated so its static backend
 server list matches the new membership (`_refresh_proxy()`).
+
+## Backup / restore test (XtraBackup)
+
+`test_backup_restore.py` exercises a full + incremental physical backup and restore
+with Percona XtraBackup. It runs **behind HAProxy only** (the proxy is irrelevant to
+backup/restore):
+
+```bash
+GR_VERBOSE=1 /Users/plavi/Development/percona/server-qa/.venv/bin/pytest -v test_backup_restore.py
+```
+
+What it does: load data with sysbench, take a **full** backup of a secondary
+(`full_backup` — XtraBackup reads the node's data volume directly while it keeps
+serving, using `LOCK INSTANCE FOR BACKUP`), run more load, take an **incremental**
+backup (`incremental_backup`) and snapshot the cluster's table checksums at that
+point, then run yet more load. It then prepares the chain (`prepare` — base with
+`--apply-log-only`, then the incremental merged without it) and restores it
+(`copy_back` — `--copy-back` then `chown -R mysql:mysql`) into a fresh **standalone**
+node started with group replication off (`start_standalone_node`). Finally it asserts
+the restored tables match the incremental-backup-time snapshot (a point-in-time check —
+the data is the state *before* the last load), and that the live cluster is untouched
+and still healthy. Expect ~4-5 minutes.
+
+XtraBackup notes:
+- Uses `percona/percona-xtrabackup:8.4`, a multi-arch image that runs natively on both
+  arm64 and amd64 (matching the Percona Server containers — XtraBackup must match the
+  server version). Override `image`/`platform` on the `XtraBackup` helper if needed.
+- Each XtraBackup step is its own one-shot `--rm` root container; backups live in a
+  per-test `grbackup_<test>` volume mounted at `/backup` (`/backup/full`, `/backup/inc1`).
+- The `xtrabackup` fixture owns the backup volume and the restore container/volume and
+  removes all of them on teardown.
+
+Relevant helpers: `XtraBackup.{full_backup,incremental_backup,prepare,copy_back}`
+(`xtrabackup_helper.py`), `GroupReplication.start_standalone_node()` and
+`table_checksums()`.
 
 ## Proxies (MySQL Router and HAProxy)
 

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -72,6 +72,7 @@ def xtrabackup(request, gr_cluster):
         gr_cluster.docker,
         network=gr_cluster.network,
         backup_volume=backup_volume,
+        root_password=gr_cluster.root_password,
         name_prefix=f"xtrabackup_{safe_node}",
         log=gr_cluster.log,
     )

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -7,20 +7,42 @@ from group_replication_helper import GroupReplication
 from sysbench_helper import Sysbench
 
 
-# Proxy modes the suite exercises in front of the cluster. HAProxy will be added
-# here later; there is intentionally no "direct" entry in the matrix.
-PROXY_KWARGS = {
+# Proxy modes the suite exercises in front of the cluster. There is intentionally
+# no "direct" entry: every test runs behind a proxy. By default a test runs under
+# all of them; restrict with @pytest.mark.proxies("haproxy") / ("router").
+PROXIES = {
     "router": {"mysql_router": True},
-    # "haproxy": {"haproxy": True},   # added in a follow-up
+    "haproxy": {"haproxy": True},
 }
 
 
-@pytest.fixture(scope="module", params=list(PROXY_KWARGS), ids=list(PROXY_KWARGS))
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "proxies(*names): restrict a test to a subset of proxy modes "
+        "(e.g. @pytest.mark.proxies('haproxy')); unmarked runs under all.",
+    )
+
+
+def pytest_generate_tests(metafunc):
+    if "gr_cluster" not in metafunc.fixturenames:
+        return
+    marker = metafunc.definition.get_closest_marker("proxies")
+    names = list(marker.args) if marker else list(PROXIES)
+    unknown = [n for n in names if n not in PROXIES]
+    if unknown:
+        raise pytest.UsageError(f"unknown proxies marker value(s): {unknown}")
+    metafunc.parametrize("gr_cluster", names, indirect=True, ids=names, scope="module")
+
+
+@pytest.fixture(scope="module")
 def gr_cluster(request):
     helper = DockerHelper()
-    cluster = GroupReplication(helper, num_nodes=3, **PROXY_KWARGS[request.param])
-    cluster.create()
+    cluster = GroupReplication(helper, num_nodes=3, **PROXIES[request.param])
     try:
+        # create() is inside the try so a partially-built cluster (e.g. a failed
+        # proxy bring-up) is still torn down instead of leaking containers.
+        cluster.create()
         yield cluster
     finally:
         cluster.destroy(remove_volumes=True)

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -19,11 +19,21 @@ PROXIES = {
 }
 
 
+def _worker_id(request) -> str:
+    """Return the pytest-xdist worker id (e.g. 'gw0'), or 'master' when running serially.
+
+    Used to make Docker container/volume names unique per worker — names are global on
+    the Docker host, so resources derived only from the test id collide across workers
+    running the same test under pytest-xdist.
+    """
+    return getattr(request.config, "workerinput", {}).get("workerid", "master")
+
+
 @pytest.fixture(scope="module")
 def gr_cluster(request):
     # request.param is supplied by each test's @pytest.mark.parametrize(..., indirect=True).
     helper = DockerHelper()
-    workerid = getattr(request.config, "workerinput", {}).get("workerid", "master")
+    workerid = _worker_id(request)
     m = re.search(r"\d+$", workerid)
     offset = int(m.group()) if m else 0
     cluster = GroupReplication(
@@ -46,9 +56,10 @@ def gr_cluster(request):
 @pytest.fixture
 def sysbench(request, gr_cluster):
     # Container names allow only [a-zA-Z0-9_.-]; the parametrized "[router]" suffix in the
-    # test node name would otherwise be rejected, so sanitize it.
+    # test node name would otherwise be rejected, so sanitize it. The worker id keeps the
+    # name unique across parallel pytest-xdist workers running the same test.
     safe_node = re.sub(r"[^a-zA-Z0-9_.-]", "_", request.node.name)
-    name = f"sysbench_{safe_node}"
+    name = f"sysbench_{_worker_id(request)}_{safe_node}"
     sb = Sysbench(gr_cluster.docker, network=gr_cluster.network, name=name, log=gr_cluster.log)
     gr_cluster.exec_sql(
         f"CREATE DATABASE IF NOT EXISTS {sb.database};"
@@ -63,17 +74,20 @@ def sysbench(request, gr_cluster):
 
 @pytest.fixture
 def xtrabackup(request, gr_cluster):
-    # Per-test resource names (container names allow only [a-zA-Z0-9_.-]).
+    # Per-test resource names (container names allow only [a-zA-Z0-9_.-]). The worker id
+    # keeps every container/volume unique across parallel pytest-xdist workers running the
+    # same test — these names are global on the Docker host.
     safe_node = re.sub(r"[^a-zA-Z0-9_.-]", "_", request.node.name)
-    backup_volume = f"grbackup_{safe_node}"
-    restore_container = f"psrestore_{safe_node}"
+    prefix = f"{_worker_id(request)}_{safe_node}"
+    backup_volume = f"grbackup_{prefix}"
+    restore_container = f"psrestore_{prefix}"
     restore_volume = f"{restore_container}-data"
     helper = XtraBackup(
         gr_cluster.docker,
         network=gr_cluster.network,
         backup_volume=backup_volume,
         root_password=gr_cluster.root_password,
-        name_prefix=f"xtrabackup_{safe_node}",
+        name_prefix=f"xtrabackup_{prefix}",
         log=gr_cluster.log,
     )
     bundle = SimpleNamespace(

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -1,7 +1,8 @@
 import pytest
 
 from docker_helper import DockerHelper
-from group_replication import GroupReplication
+from group_replication_helper import GroupReplication
+from sysbench_helper import Sysbench
 
 
 @pytest.fixture(scope="module")
@@ -13,3 +14,19 @@ def gr_cluster():
         yield cluster
     finally:
         cluster.destroy(remove_volumes=True)
+
+
+@pytest.fixture
+def sysbench(request, gr_cluster):
+    name = f"sysbench_{request.node.name}"
+    sb = Sysbench(gr_cluster.docker, network=gr_cluster.network, name=name, log=gr_cluster.log)
+    gr_cluster.docker.exec_mysql(
+        gr_cluster.get_primary(),
+        f"CREATE DATABASE IF NOT EXISTS {sb.database};"
+        f"CREATE USER IF NOT EXISTS '{sb.mysql_user}'@'%' IDENTIFIED BY '{sb.mysql_password}';"
+        f"GRANT ALL ON {sb.database}.* TO '{sb.mysql_user}'@'%';",
+    )
+    try:
+        yield sb
+    finally:
+        gr_cluster.docker.destroy(name)

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+from docker_helper import DockerHelper
+from group_replication import GroupReplication
+
+
+@pytest.fixture(scope="module")
+def gr_cluster():
+    helper = DockerHelper()
+    cluster = GroupReplication(helper, num_nodes=3)
+    cluster.create()
+    try:
+        yield cluster
+    finally:
+        cluster.destroy(remove_volumes=True)

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -7,36 +7,19 @@ from group_replication_helper import GroupReplication
 from sysbench_helper import Sysbench
 
 
-# Proxy modes the suite exercises in front of the cluster. There is intentionally
-# no "direct" entry: every test runs behind a proxy. By default a test runs under
-# all of them; restrict with @pytest.mark.proxies("haproxy") / ("router").
+# Proxy modes the suite can run a test behind. There is intentionally no "direct"
+# entry: every test runs behind a proxy. Each test selects its proxies explicitly
+# with @pytest.mark.parametrize("gr_cluster", [...], indirect=True) — see the test
+# files. The value passed (e.g. "router"/"haproxy") is the key looked up here.
 PROXIES = {
     "router": {"mysql_router": True},
     "haproxy": {"haproxy": True},
 }
 
 
-def pytest_configure(config):
-    config.addinivalue_line(
-        "markers",
-        "proxies(*names): restrict a test to a subset of proxy modes "
-        "(e.g. @pytest.mark.proxies('haproxy')); unmarked runs under all.",
-    )
-
-
-def pytest_generate_tests(metafunc):
-    if "gr_cluster" not in metafunc.fixturenames:
-        return
-    marker = metafunc.definition.get_closest_marker("proxies")
-    names = list(marker.args) if marker else list(PROXIES)
-    unknown = [n for n in names if n not in PROXIES]
-    if unknown:
-        raise pytest.UsageError(f"unknown proxies marker value(s): {unknown}")
-    metafunc.parametrize("gr_cluster", names, indirect=True, ids=names, scope="module")
-
-
 @pytest.fixture(scope="module")
 def gr_cluster(request):
+    # request.param is supplied by each test's @pytest.mark.parametrize(..., indirect=True).
     helper = DockerHelper()
     cluster = GroupReplication(helper, num_nodes=3, **PROXIES[request.param])
     try:

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -20,13 +20,13 @@ PROXIES = {
 
 
 def _worker_id(request) -> str:
-    """Return the pytest-xdist worker id (e.g. 'gw0'), or 'master' when running serially.
+    """Return the pytest-xdist worker id (e.g. 'gw0'), or '0' when running serially.
 
     Used to make Docker container/volume names unique per worker — names are global on
     the Docker host, so resources derived only from the test id collide across workers
     running the same test under pytest-xdist.
     """
-    return getattr(request.config, "workerinput", {}).get("workerid", "master")
+    return getattr(request.config, "workerinput", {}).get("workerid", "0")
 
 
 @pytest.fixture(scope="module")

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -29,6 +29,16 @@ def _worker_id(request) -> str:
     return getattr(request.config, "workerinput", {}).get("workerid", "0")
 
 
+def _sql_ident(name: str) -> str:
+    """Quote a MySQL identifier (e.g. a database name), escaping embedded backticks."""
+    return "`" + name.replace("`", "``") + "`"
+
+
+def _sql_str(value: str) -> str:
+    """Quote a MySQL string literal, escaping backslashes and single quotes (default sql_mode)."""
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
 @pytest.fixture(scope="module")
 def gr_cluster(request):
     # request.param is supplied by each test's @pytest.mark.parametrize(..., indirect=True).
@@ -61,10 +71,13 @@ def sysbench(request, gr_cluster):
     safe_node = re.sub(r"[^a-zA-Z0-9_.-]", "_", request.node.name)
     name = f"sysbench_{_worker_id(request)}_{safe_node}"
     sb = Sysbench(gr_cluster.docker, network=gr_cluster.network, name=name, log=gr_cluster.log)
+    db = _sql_ident(sb.database)
+    user = _sql_str(sb.mysql_user)
+    password = _sql_str(sb.mysql_password)
     gr_cluster.exec_sql(
-        f"CREATE DATABASE IF NOT EXISTS {sb.database};"
-        f"CREATE USER IF NOT EXISTS '{sb.mysql_user}'@'%' IDENTIFIED BY '{sb.mysql_password}';"
-        f"GRANT ALL ON {sb.database}.* TO '{sb.mysql_user}'@'%';",
+        f"CREATE DATABASE IF NOT EXISTS {db};"
+        f"CREATE USER IF NOT EXISTS {user}@'%' IDENTIFIED BY {password};"
+        f"GRANT ALL ON {db}.* TO {user}@'%';",
     )
     try:
         yield sb

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -77,6 +77,11 @@ def gr_cluster(request):
         base_host_port=33060 + offset * 100,
         **PROXIES[proxy],
     )
+    # The cluster is bootstrapped via mysqlsh's AdminAPI; skip rather than fail the whole
+    # suite when the server image ships without MySQL Shell. Checked before create() so no
+    # nodes are started when it's missing.
+    if not cluster.mysqlsh_available():
+        pytest.skip(f"mysqlsh not available in server image {cluster.server_image!r}")
     try:
         # create() is inside the try so a partially-built cluster (e.g. a failed
         # proxy bring-up) is still torn down instead of leaking containers.

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -43,13 +43,19 @@ def gr_cluster(request):
     # request.param is supplied by each test's @pytest.mark.parametrize(..., indirect=True).
     helper = DockerHelper()
     workerid = _worker_id(request)
+    # Use the full worker id (sanitized to [a-zA-Z0-9]) for the globally-unique resource
+    # names: deriving node_prefix from offset alone collapses "0" (serial) and "gw0"
+    # (xdist) to the same "ps0-" prefix, which would clash across execution modes. offset
+    # (the numeric suffix) is used only to give concurrent xdist workers distinct host
+    # port ranges.
+    safe_workerid = re.sub(r"[^a-zA-Z0-9]", "", workerid) or "0"
     m = re.search(r"\d+$", workerid)
     offset = int(m.group()) if m else 0
     cluster = GroupReplication(
         helper,
         num_nodes=3,
-        network=f"grnet-{workerid}",
-        node_prefix=f"ps{offset}-",
+        network=f"grnet-{safe_workerid}",
+        node_prefix=f"ps{safe_workerid}-",
         base_host_port=33060 + offset * 100,
         **PROXIES[request.param],
     )

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -23,8 +23,17 @@ PROXIES = {
 def gr_cluster(request):
     # request.param is supplied by each test's @pytest.mark.parametrize(..., indirect=True).
     helper = DockerHelper()
-    cluster = GroupReplication(helper, num_nodes=3, **PROXIES[request.param])
-    try:
+    workerid = getattr(request.config, "workerinput", {}).get("workerid", "master")
+    m = re.search(r"\d+$", workerid)
+    offset = int(m.group()) if m else 0
+    cluster = GroupReplication(
+        helper,
+        num_nodes=3,
+        network=f"grnet-{workerid}",
+        node_prefix=f"ps{offset}-",
+        base_host_port=33060 + offset * 100,
+        **PROXIES[request.param],
+    )
         # create() is inside the try so a partially-built cluster (e.g. a failed
         # proxy bring-up) is still torn down instead of leaking containers.
         cluster.create()

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -12,6 +12,7 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from docker_helper import DockerHelper  # noqa: E402
+from generic_helper import sql_ident, sql_str  # noqa: E402
 from group_replication_helper import GroupReplication  # noqa: E402
 from sysbench_helper import Sysbench  # noqa: E402
 from xtrabackup_helper import XtraBackup  # noqa: E402
@@ -35,16 +36,6 @@ def _worker_id(request) -> str:
     running the same test under pytest-xdist.
     """
     return getattr(request.config, "workerinput", {}).get("workerid", "0")
-
-
-def _sql_ident(name: str) -> str:
-    """Quote a MySQL identifier (e.g. a database name), escaping embedded backticks."""
-    return "`" + name.replace("`", "``") + "`"
-
-
-def _sql_str(value: str) -> str:
-    """Quote a MySQL string literal, escaping backslashes and single quotes (default sql_mode)."""
-    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
 
 
 @pytest.fixture(scope="module")
@@ -79,9 +70,9 @@ def sysbench(request, gr_cluster):
     safe_node = re.sub(r"[^a-zA-Z0-9_.-]", "_", request.node.name)
     name = f"sysbench_{_worker_id(request)}_{safe_node}"
     sb = Sysbench(gr_cluster.docker, network=gr_cluster.network, name=name, log=gr_cluster.log)
-    db = _sql_ident(sb.database)
-    user = _sql_str(sb.mysql_user)
-    password = _sql_str(sb.mysql_password)
+    db = sql_ident(sb.database)
+    user = sql_str(sb.mysql_user)
+    password = sql_str(sb.mysql_password)
     gr_cluster.exec_sql(
         f"CREATE DATABASE IF NOT EXISTS {db};"
         f"CREATE USER IF NOT EXISTS {user}@'%' IDENTIFIED BY {password};"

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -1,12 +1,20 @@
+import os
 import re
+import sys
 from types import SimpleNamespace
 
 import pytest
 
-from docker_helper import DockerHelper
-from group_replication_helper import GroupReplication
-from sysbench_helper import Sysbench
-from xtrabackup_helper import XtraBackup
+# The helper modules below are imported as top-level modules. This directory can't be a
+# package (the 'group-replication' hyphen is not a valid identifier), so add it to
+# sys.path explicitly — otherwise importing them fails when pytest is invoked from a
+# different working directory (e.g. the repo root in CI).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from docker_helper import DockerHelper  # noqa: E402
+from group_replication_helper import GroupReplication  # noqa: E402
+from sysbench_helper import Sysbench  # noqa: E402
+from xtrabackup_helper import XtraBackup  # noqa: E402
 
 
 # Proxy modes the suite can run a test behind. There is intentionally no "direct"

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from docker_helper import DockerHelper
@@ -5,10 +7,18 @@ from group_replication_helper import GroupReplication
 from sysbench_helper import Sysbench
 
 
-@pytest.fixture(scope="module")
-def gr_cluster():
+# Proxy modes the suite exercises in front of the cluster. HAProxy will be added
+# here later; there is intentionally no "direct" entry in the matrix.
+PROXY_KWARGS = {
+    "router": {"mysql_router": True},
+    # "haproxy": {"haproxy": True},   # added in a follow-up
+}
+
+
+@pytest.fixture(scope="module", params=list(PROXY_KWARGS), ids=list(PROXY_KWARGS))
+def gr_cluster(request):
     helper = DockerHelper()
-    cluster = GroupReplication(helper, num_nodes=3)
+    cluster = GroupReplication(helper, num_nodes=3, **PROXY_KWARGS[request.param])
     cluster.create()
     try:
         yield cluster
@@ -18,10 +28,12 @@ def gr_cluster():
 
 @pytest.fixture
 def sysbench(request, gr_cluster):
-    name = f"sysbench_{request.node.name}"
+    # Container names allow only [a-zA-Z0-9_.-]; the parametrized "[router]" suffix in the
+    # test node name would otherwise be rejected, so sanitize it.
+    safe_node = re.sub(r"[^a-zA-Z0-9_.-]", "_", request.node.name)
+    name = f"sysbench_{safe_node}"
     sb = Sysbench(gr_cluster.docker, network=gr_cluster.network, name=name, log=gr_cluster.log)
-    gr_cluster.docker.exec_mysql(
-        gr_cluster.get_primary(),
+    gr_cluster.exec_sql(
         f"CREATE DATABASE IF NOT EXISTS {sb.database};"
         f"CREATE USER IF NOT EXISTS '{sb.mysql_user}'@'%' IDENTIFIED BY '{sb.mysql_password}';"
         f"GRANT ALL ON {sb.database}.* TO '{sb.mysql_user}'@'%';",

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -40,7 +40,20 @@ def _worker_id(request) -> str:
 
 @pytest.fixture(scope="module")
 def gr_cluster(request):
-    # request.param is supplied by each test's @pytest.mark.parametrize(..., indirect=True).
+    # request.param is the proxy, supplied by each test's
+    # @pytest.mark.parametrize("gr_cluster", [...], indirect=True). Validate it explicitly
+    # so a test that forgets the decorator fails with a clear message instead of an opaque
+    # AttributeError (no param) / KeyError (unknown proxy).
+    proxy = getattr(request, "param", None)
+    if proxy is None:
+        raise pytest.UsageError(
+            'gr_cluster requires a proxy via indirect parametrization, e.g. '
+            '@pytest.mark.parametrize("gr_cluster", ["haproxy"], indirect=True)'
+        )
+    if proxy not in PROXIES:
+        raise pytest.UsageError(
+            f"unknown gr_cluster proxy {proxy!r}; valid options: {sorted(PROXIES)}"
+        )
     try:
         helper = DockerHelper()
     except RuntimeError as exc:
@@ -62,7 +75,7 @@ def gr_cluster(request):
         network=f"grnet-{safe_workerid}",
         node_prefix=f"ps{safe_workerid}-",
         base_host_port=33060 + offset * 100,
-        **PROXIES[request.param],
+        **PROXIES[proxy],
     )
     try:
         # create() is inside the try so a partially-built cluster (e.g. a failed

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -1,10 +1,12 @@
 import re
+from types import SimpleNamespace
 
 import pytest
 
 from docker_helper import DockerHelper
 from group_replication_helper import GroupReplication
 from sysbench_helper import Sysbench
+from xtrabackup_helper import XtraBackup
 
 
 # Proxy modes the suite can run a test behind. There is intentionally no "direct"
@@ -47,3 +49,30 @@ def sysbench(request, gr_cluster):
         yield sb
     finally:
         gr_cluster.docker.destroy(name)
+
+
+@pytest.fixture
+def xtrabackup(request, gr_cluster):
+    # Per-test resource names (container names allow only [a-zA-Z0-9_.-]).
+    safe_node = re.sub(r"[^a-zA-Z0-9_.-]", "_", request.node.name)
+    backup_volume = f"grbackup_{safe_node}"
+    restore_container = f"psrestore_{safe_node}"
+    restore_volume = f"{restore_container}-data"
+    helper = XtraBackup(
+        gr_cluster.docker,
+        network=gr_cluster.network,
+        backup_volume=backup_volume,
+        name_prefix=f"xtrabackup_{safe_node}",
+        log=gr_cluster.log,
+    )
+    bundle = SimpleNamespace(
+        helper=helper,
+        restore_container=restore_container,
+        restore_volume=restore_volume,
+    )
+    try:
+        yield bundle
+    finally:
+        gr_cluster.docker.destroy(restore_container)
+        gr_cluster.docker.volume_remove(restore_volume)
+        helper.cleanup()

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -34,6 +34,7 @@ def gr_cluster(request):
         base_host_port=33060 + offset * 100,
         **PROXIES[request.param],
     )
+    try:
         # create() is inside the try so a partially-built cluster (e.g. a failed
         # proxy bring-up) is still torn down instead of leaking containers.
         cluster.create()

--- a/test_scripts/ps/group-replication/conftest.py
+++ b/test_scripts/ps/group-replication/conftest.py
@@ -41,7 +41,12 @@ def _worker_id(request) -> str:
 @pytest.fixture(scope="module")
 def gr_cluster(request):
     # request.param is supplied by each test's @pytest.mark.parametrize(..., indirect=True).
-    helper = DockerHelper()
+    try:
+        helper = DockerHelper()
+    except RuntimeError as exc:
+        # No docker/podman on PATH: skip rather than error the whole run (e.g. when the
+        # suite is collected in an environment without a container runtime).
+        pytest.skip(f"no container runtime available: {exc}")
     workerid = _worker_id(request)
     # Use the full worker id (sanitized to [a-zA-Z0-9]) for the globally-unique resource
     # names: deriving node_prefix from offset alone collapses "0" (serial) and "gw0"

--- a/test_scripts/ps/group-replication/docker_helper.py
+++ b/test_scripts/ps/group-replication/docker_helper.py
@@ -63,7 +63,7 @@ class DockerHelper:
         except subprocess.TimeoutExpired as exc:
             result = ExecResult(
                 stdout=exc.stdout or "",
-                stderr=f"timed out after {timeout}s",
+                stderr=(exc.stderr or "").strip() or f"timed out after {timeout}s",
                 returncode=124,
             )
         else:

--- a/test_scripts/ps/group-replication/docker_helper.py
+++ b/test_scripts/ps/group-replication/docker_helper.py
@@ -115,6 +115,9 @@ class DockerHelper:
         networks: list[str] | None = None,
         entrypoint: str | None = None,
         command: list[str] | None = None,
+        volumes: list[str] | None = None,
+        user: str | None = None,
+        platform: str | None = None,
         remove: bool = True,
         check: bool = True,
     ) -> ExecResult:
@@ -124,8 +127,14 @@ class DockerHelper:
             args.append("--rm")
         if name:
             args.extend(["--name", name])
+        if platform:
+            args.extend(["--platform", platform])
+        if user:
+            args.extend(["--user", user])
         if entrypoint:
             args.extend(["--entrypoint", entrypoint])
+        for vol in volumes or []:
+            args.extend(["-v", vol])
         for net in networks or []:
             args.extend(["--network", net])
         args.append(image)

--- a/test_scripts/ps/group-replication/docker_helper.py
+++ b/test_scripts/ps/group-replication/docker_helper.py
@@ -123,6 +123,11 @@ class DockerHelper:
         check: bool = True,
     ) -> ExecResult:
         """Run a one-off (by default --rm) container, e.g. an ephemeral helper task."""
+        # --rm only cleans up on a clean exit; an interrupted prior run can leave a
+        # container with this name behind, making `run --name` fail with a conflict.
+        # Remove any leftover first so reruns are idempotent.
+        if name:
+            self.destroy(name)
         args = ["run"]
         if remove:
             args.append("--rm")

--- a/test_scripts/ps/group-replication/docker_helper.py
+++ b/test_scripts/ps/group-replication/docker_helper.py
@@ -72,7 +72,7 @@ class DockerHelper:
         hostname: str | None = None,
         environment: dict[str, str] | None = None,
         volumes: list[str] | None = None,
-        networks: list[str] | None = None,
+        network: str | None = None,
         ports: list[str] | None = None,
         entrypoint: str | None = None,
         command: list[str] | None = None,
@@ -99,8 +99,8 @@ class DockerHelper:
             args.extend(["-e", f"{k}={v}"])
         for vol in volumes or []:
             args.extend(["-v", vol])
-        for net in networks or []:
-            args.extend(["--network", net])
+        if network:
+            args.extend(["--network", network])
         for port in ports or []:
             args.extend(["-p", port])
         args.append(image)
@@ -112,7 +112,7 @@ class DockerHelper:
         self,
         image: str,
         name: str | None = None,
-        networks: list[str] | None = None,
+        network: str | None = None,
         entrypoint: str | None = None,
         command: list[str] | None = None,
         volumes: list[str] | None = None,
@@ -135,8 +135,8 @@ class DockerHelper:
             args.extend(["--entrypoint", entrypoint])
         for vol in volumes or []:
             args.extend(["-v", vol])
-        for net in networks or []:
-            args.extend(["--network", net])
+        if network:
+            args.extend(["--network", network])
         args.append(image)
         if command:
             args.extend(command)

--- a/test_scripts/ps/group-replication/docker_helper.py
+++ b/test_scripts/ps/group-replication/docker_helper.py
@@ -31,6 +31,7 @@ class DockerHelper:
         self.cli = cli
 
     def _run(self, args: list[str], check: bool = True, input_text: str | None = None) -> ExecResult:
+        """Run a container CLI command and return its result, raising on failure when check is set."""
         proc = subprocess.run(
             [self.cli, *args],
             capture_output=True,
@@ -58,6 +59,7 @@ class DockerHelper:
         detach: bool = True,
         restart: str | None = None,
     ) -> ExecResult:
+        """Create and start a long-lived (detached) container with the given config."""
         args = ["run"]
         if detach:
             args.append("-d")
@@ -89,6 +91,7 @@ class DockerHelper:
         remove: bool = True,
         check: bool = True,
     ) -> ExecResult:
+        """Run a one-off (by default --rm) container, e.g. an ephemeral helper task."""
         args = ["run"]
         if remove:
             args.append("--rm")
@@ -104,15 +107,19 @@ class DockerHelper:
         return self._run(args, check=check)
 
     def destroy(self, name: str) -> ExecResult:
+        """Force-remove a container, ignoring errors if it does not exist."""
         return self._run(["rm", "-f", name], check=False)
 
     def start(self, name: str) -> ExecResult:
+        """Start an existing stopped container."""
         return self._run(["start", name])
 
     def stop(self, name: str) -> ExecResult:
+        """Stop a running container."""
         return self._run(["stop", name])
 
     def exec_command(self, name: str, command: str, check: bool = False) -> ExecResult:
+        """Run a shell command inside a running container."""
         return self._run(["exec", name, "sh", "-c", command], check=check)
 
     def exec_mysql(
@@ -124,6 +131,7 @@ class DockerHelper:
         database: str | None = None,
         check: bool = True,
     ) -> ExecResult:
+        """Run a SQL statement inside a container using the mysql client."""
         args = ["exec", name, "mysql", f"-u{user}", f"-p{password}", "-N", "-B"]
         if database:
             args.extend(["-D", database])
@@ -141,6 +149,7 @@ class DockerHelper:
         language: str = "js",
         check: bool = True,
     ) -> ExecResult:
+        """Run a MySQL Shell (mysqlsh) script inside a container against the given URI."""
         uri = f"{user}:{password}@{host}:{port}"
         args = [
             "exec",
@@ -157,6 +166,7 @@ class DockerHelper:
         return self._run(args, check=check)
 
     def network_create(self, name: str) -> ExecResult:
+        """Create a container network, reusing it if one with the same name already exists."""
         existing = self._run(
             ["network", "ls", "--filter", f"name=^{name}$", "--format", "{{.Name}}"],
             check=False,
@@ -166,12 +176,15 @@ class DockerHelper:
         return self._run(["network", "create", name])
 
     def network_remove(self, name: str) -> ExecResult:
+        """Remove a container network, ignoring errors if it does not exist."""
         return self._run(["network", "rm", name], check=False)
 
     def volume_remove(self, name: str) -> ExecResult:
+        """Remove a container volume, ignoring errors if it does not exist."""
         return self._run(["volume", "rm", name], check=False)
 
     def container_exists(self, name: str) -> bool:
+        """Return True if a container with the exact given name exists (running or stopped)."""
         result = self._run(
             ["ps", "-a", "--filter", f"name=^{name}$", "--format", "{{.Names}}"],
             check=False,

--- a/test_scripts/ps/group-replication/docker_helper.py
+++ b/test_scripts/ps/group-replication/docker_helper.py
@@ -1,0 +1,155 @@
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass
+class ExecResult:
+    stdout: str
+    stderr: str
+    returncode: int
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+class DockerHelper:
+    def __init__(self, cli: str | None = None):
+        if cli is None:
+            cli = os.environ.get("CONTAINER_CLI")
+        if cli is None:
+            for candidate in ("docker", "podman"):
+                if shutil.which(candidate):
+                    cli = candidate
+                    break
+        if not cli:
+            raise RuntimeError(
+                "No container CLI found. Install docker or podman, or set CONTAINER_CLI."
+            )
+        self.cli = cli
+
+    def _run(self, args: list[str], check: bool = True, input_text: str | None = None) -> ExecResult:
+        proc = subprocess.run(
+            [self.cli, *args],
+            capture_output=True,
+            text=True,
+            input=input_text,
+        )
+        result = ExecResult(stdout=proc.stdout, stderr=proc.stderr, returncode=proc.returncode)
+        if check and not result.ok:
+            raise RuntimeError(
+                f"{self.cli} {' '.join(args)} failed (exit {proc.returncode})\n"
+                f"stdout: {proc.stdout}\nstderr: {proc.stderr}"
+            )
+        return result
+
+    def create(
+        self,
+        image: str,
+        name: str,
+        hostname: str | None = None,
+        environment: dict[str, str] | None = None,
+        volumes: list[str] | None = None,
+        networks: list[str] | None = None,
+        ports: list[str] | None = None,
+        command: list[str] | None = None,
+        detach: bool = True,
+        restart: str | None = None,
+    ) -> ExecResult:
+        args = ["run"]
+        if detach:
+            args.append("-d")
+        args.extend(["--name", name])
+        if hostname:
+            args.extend(["--hostname", hostname])
+        if restart:
+            args.extend(["--restart", restart])
+        for k, v in (environment or {}).items():
+            args.extend(["-e", f"{k}={v}"])
+        for vol in volumes or []:
+            args.extend(["-v", vol])
+        for net in networks or []:
+            args.extend(["--network", net])
+        for port in ports or []:
+            args.extend(["-p", port])
+        args.append(image)
+        if command:
+            args.extend(command)
+        return self._run(args)
+
+    def destroy(self, name: str) -> ExecResult:
+        return self._run(["rm", "-f", name], check=False)
+
+    def start(self, name: str) -> ExecResult:
+        return self._run(["start", name])
+
+    def stop(self, name: str) -> ExecResult:
+        return self._run(["stop", name])
+
+    def exec_command(self, name: str, command: str, check: bool = False) -> ExecResult:
+        return self._run(["exec", name, "sh", "-c", command], check=check)
+
+    def exec_mysql(
+        self,
+        name: str,
+        sql: str,
+        user: str = "root",
+        password: str = "rootpass",
+        database: str | None = None,
+        check: bool = True,
+    ) -> ExecResult:
+        args = ["exec", name, "mysql", f"-u{user}", f"-p{password}", "-N", "-B"]
+        if database:
+            args.extend(["-D", database])
+        args.extend(["-e", sql])
+        return self._run(args, check=check)
+
+    def exec_mysqlsh(
+        self,
+        name: str,
+        script: str,
+        user: str = "root",
+        password: str = "rootpass",
+        host: str = "localhost",
+        port: int = 3306,
+        language: str = "js",
+        check: bool = True,
+    ) -> ExecResult:
+        uri = f"{user}:{password}@{host}:{port}"
+        args = [
+            "exec",
+            "-i",
+            name,
+            "mysqlsh",
+            "--no-wizard",
+            "--uri",
+            uri,
+            f"--{language}",
+            "-e",
+            script,
+        ]
+        return self._run(args, check=check)
+
+    def network_create(self, name: str) -> ExecResult:
+        existing = self._run(
+            ["network", "ls", "--filter", f"name=^{name}$", "--format", "{{.Name}}"],
+            check=False,
+        )
+        if existing.ok and existing.stdout.strip() == name:
+            return existing
+        return self._run(["network", "create", name])
+
+    def network_remove(self, name: str) -> ExecResult:
+        return self._run(["network", "rm", name], check=False)
+
+    def volume_remove(self, name: str) -> ExecResult:
+        return self._run(["volume", "rm", name], check=False)
+
+    def container_exists(self, name: str) -> bool:
+        result = self._run(
+            ["ps", "-a", "--filter", f"name=^{name}$", "--format", "{{.Names}}"],
+            check=False,
+        )
+        return result.ok and result.stdout.strip() == name

--- a/test_scripts/ps/group-replication/docker_helper.py
+++ b/test_scripts/ps/group-replication/docker_helper.py
@@ -143,8 +143,14 @@ class DockerHelper:
         return self._run(args, check=check)
 
     def destroy(self, name: str) -> ExecResult:
-        """Force-remove a container, ignoring errors if it does not exist."""
-        return self._run(["rm", "-f", name], check=False)
+        """Force-remove a container and its anonymous volumes, ignoring errors if absent.
+
+        The -v flag drops anonymous volumes the image declares (e.g. /var/log/mysql on
+        the server image, /etc/haproxy/pxc on the HAProxy image) that we never bind to a
+        named volume — otherwise they leak on every run. Named volumes (mounted by name)
+        are not affected and are removed explicitly via volume_remove.
+        """
+        return self._run(["rm", "-f", "-v", name], check=False)
 
     def start(self, name: str) -> ExecResult:
         """Start an existing stopped container."""

--- a/test_scripts/ps/group-replication/docker_helper.py
+++ b/test_scripts/ps/group-replication/docker_helper.py
@@ -82,6 +82,11 @@ class DockerHelper:
         platform: str | None = None,
     ) -> ExecResult:
         """Create and start a long-lived (detached) container with the given config."""
+        # These containers are long-lived (no --rm), so a run that crashed before teardown
+        # leaves one with this name behind, making `run --name` fail with a conflict.
+        # Remove any leftover first so reruns are idempotent (named data volumes survive
+        # `rm -f -v`, so this only drops the stale container, not its data).
+        self.destroy(name)
         args = ["run"]
         if detach:
             args.append("-d")

--- a/test_scripts/ps/group-replication/docker_helper.py
+++ b/test_scripts/ps/group-replication/docker_helper.py
@@ -19,8 +19,17 @@ class ExecResult:
 class DockerHelper:
     def __init__(self, cli: str | None = None):
         if cli is None:
-            cli = os.environ.get("CONTAINER_CLI")
-        if cli is None:
+            # Treat an empty CONTAINER_CLI as unset so it falls back to auto-detection.
+            cli = os.environ.get("CONTAINER_CLI") or None
+        if cli is not None:
+            # An explicitly chosen CLI (argument or CONTAINER_CLI) must actually exist on
+            # PATH, otherwise every command later fails with an opaque FileNotFoundError.
+            if not shutil.which(cli):
+                raise RuntimeError(
+                    f"Container CLI {cli!r} (from the cli argument or CONTAINER_CLI) was "
+                    "not found on PATH. Install it or set CONTAINER_CLI correctly."
+                )
+        else:
             for candidate in ("docker", "podman"):
                 if shutil.which(candidate):
                     cli = candidate

--- a/test_scripts/ps/group-replication/docker_helper.py
+++ b/test_scripts/ps/group-replication/docker_helper.py
@@ -55,6 +55,7 @@ class DockerHelper:
         volumes: list[str] | None = None,
         networks: list[str] | None = None,
         ports: list[str] | None = None,
+        entrypoint: str | None = None,
         command: list[str] | None = None,
         detach: bool = True,
         restart: str | None = None,
@@ -66,6 +67,8 @@ class DockerHelper:
         args.extend(["--name", name])
         if hostname:
             args.extend(["--hostname", hostname])
+        if entrypoint:
+            args.extend(["--entrypoint", entrypoint])
         if restart:
             args.extend(["--restart", restart])
         for k, v in (environment or {}).items():
@@ -129,10 +132,21 @@ class DockerHelper:
         user: str = "root",
         password: str = "rootpass",
         database: str | None = None,
+        host: str | None = None,
+        port: int | None = None,
         check: bool = True,
     ) -> ExecResult:
-        """Run a SQL statement inside a container using the mysql client."""
+        """Run a SQL statement inside a container using the mysql client.
+
+        With host/port omitted the client uses the container's local socket. Pass
+        host/port to connect over TCP instead (e.g. through MySQL Router).
+        """
         args = ["exec", name, "mysql", f"-u{user}", f"-p{password}", "-N", "-B"]
+        if host:
+            args.append(f"-h{host}")
+        if port:
+            # Force TCP so a host such as "localhost" is not silently swapped for the socket.
+            args.extend([f"-P{port}", "--protocol=TCP"])
         if database:
             args.extend(["-D", database])
         args.extend(["-e", sql])

--- a/test_scripts/ps/group-replication/docker_helper.py
+++ b/test_scripts/ps/group-replication/docker_helper.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess
 from dataclasses import dataclass
+from urllib.parse import quote
 
 
 @dataclass
@@ -205,7 +206,9 @@ class DockerHelper:
         check: bool = True,
     ) -> ExecResult:
         """Run a MySQL Shell (mysqlsh) script inside a container against the given URI."""
-        uri = f"{user}:{password}@{host}:{port}"
+        # Percent-encode the credentials so a user/password containing URI-reserved
+        # characters (@ : / # ?) doesn't make mysqlsh misparse the connection string.
+        uri = f"{quote(user, safe='')}:{quote(password, safe='')}@{host}:{port}"
         args = [
             "exec",
             "-i",

--- a/test_scripts/ps/group-replication/docker_helper.py
+++ b/test_scripts/ps/group-replication/docker_helper.py
@@ -204,8 +204,13 @@ class DockerHelper:
         port: int = 3306,
         language: str = "js",
         check: bool = True,
+        timeout: float | None = None,
     ) -> ExecResult:
-        """Run a MySQL Shell (mysqlsh) script inside a container against the given URI."""
+        """Run a MySQL Shell (mysqlsh) script inside a container against the given URI.
+
+        A timeout (seconds) bounds the call so a stuck mysqlsh (e.g. waiting on a
+        connection) can't hang the run until an outer pytest timeout.
+        """
         # Percent-encode the credentials so a user/password containing URI-reserved
         # characters (@ : / # ?) doesn't make mysqlsh misparse the connection string.
         uri = f"{quote(user, safe='')}:{quote(password, safe='')}@{host}:{port}"
@@ -221,7 +226,7 @@ class DockerHelper:
             "-e",
             script,
         ]
-        return self._run(args, check=check)
+        return self._run(args, check=check, timeout=timeout)
 
     def network_create(self, name: str) -> ExecResult:
         """Create a container network, reusing it if one with the same name already exists."""

--- a/test_scripts/ps/group-replication/docker_helper.py
+++ b/test_scripts/ps/group-replication/docker_helper.py
@@ -30,19 +30,38 @@ class DockerHelper:
             )
         self.cli = cli
 
-    def _run(self, args: list[str], check: bool = True, input_text: str | None = None) -> ExecResult:
-        """Run a container CLI command and return its result, raising on failure when check is set."""
-        proc = subprocess.run(
-            [self.cli, *args],
-            capture_output=True,
-            text=True,
-            input=input_text,
-        )
-        result = ExecResult(stdout=proc.stdout, stderr=proc.stderr, returncode=proc.returncode)
+    def _run(
+        self,
+        args: list[str],
+        check: bool = True,
+        input_text: str | None = None,
+        timeout: float | None = None,
+    ) -> ExecResult:
+        """Run a container CLI command and return its result, raising on failure when check is set.
+
+        A timeout (seconds) bounds how long the call may block; on timeout the process is killed and
+        a non-ok result is returned (or raised when check is set), so a hung connection can't stall forever.
+        """
+        try:
+            proc = subprocess.run(
+                [self.cli, *args],
+                capture_output=True,
+                text=True,
+                input=input_text,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            result = ExecResult(
+                stdout=exc.stdout or "",
+                stderr=f"timed out after {timeout}s",
+                returncode=124,
+            )
+        else:
+            result = ExecResult(stdout=proc.stdout, stderr=proc.stderr, returncode=proc.returncode)
         if check and not result.ok:
             raise RuntimeError(
-                f"{self.cli} {' '.join(args)} failed (exit {proc.returncode})\n"
-                f"stdout: {proc.stdout}\nstderr: {proc.stderr}"
+                f"{self.cli} {' '.join(args)} failed (exit {result.returncode})\n"
+                f"stdout: {result.stdout}\nstderr: {result.stderr}"
             )
         return result
 
@@ -59,12 +78,17 @@ class DockerHelper:
         command: list[str] | None = None,
         detach: bool = True,
         restart: str | None = None,
+        platform: str | None = None,
     ) -> ExecResult:
         """Create and start a long-lived (detached) container with the given config."""
         args = ["run"]
         if detach:
             args.append("-d")
         args.extend(["--name", name])
+        if platform:
+            # Needed for multi-arch manifest-list images with no native variant
+            # (e.g. an amd64-only image on Apple Silicon).
+            args.extend(["--platform", platform])
         if hostname:
             args.extend(["--hostname", hostname])
         if entrypoint:
@@ -135,11 +159,13 @@ class DockerHelper:
         host: str | None = None,
         port: int | None = None,
         check: bool = True,
+        timeout: float | None = None,
     ) -> ExecResult:
         """Run a SQL statement inside a container using the mysql client.
 
         With host/port omitted the client uses the container's local socket. Pass
-        host/port to connect over TCP instead (e.g. through MySQL Router).
+        host/port to connect over TCP instead (e.g. through a proxy). A timeout (seconds)
+        bounds the call so a connection that hangs (e.g. a proxy with no live backend) can't block.
         """
         args = ["exec", name, "mysql", f"-u{user}", f"-p{password}", "-N", "-B"]
         if host:
@@ -150,7 +176,7 @@ class DockerHelper:
         if database:
             args.extend(["-D", database])
         args.extend(["-e", sql])
-        return self._run(args, check=check)
+        return self._run(args, check=check, timeout=timeout)
 
     def exec_mysqlsh(
         self,

--- a/test_scripts/ps/group-replication/docker_helper.py
+++ b/test_scripts/ps/group-replication/docker_helper.py
@@ -79,6 +79,30 @@ class DockerHelper:
             args.extend(command)
         return self._run(args)
 
+    def run(
+        self,
+        image: str,
+        name: str | None = None,
+        networks: list[str] | None = None,
+        entrypoint: str | None = None,
+        command: list[str] | None = None,
+        remove: bool = True,
+        check: bool = True,
+    ) -> ExecResult:
+        args = ["run"]
+        if remove:
+            args.append("--rm")
+        if name:
+            args.extend(["--name", name])
+        if entrypoint:
+            args.extend(["--entrypoint", entrypoint])
+        for net in networks or []:
+            args.extend(["--network", net])
+        args.append(image)
+        if command:
+            args.extend(command)
+        return self._run(args, check=check)
+
     def destroy(self, name: str) -> ExecResult:
         return self._run(["rm", "-f", name], check=False)
 

--- a/test_scripts/ps/group-replication/generic_helper.py
+++ b/test_scripts/ps/group-replication/generic_helper.py
@@ -1,0 +1,27 @@
+"""Small, dependency-free string-escaping helpers shared across the suite.
+
+These keep dynamic values (database names, credentials, identifiers) from breaking — or
+being injectable into — the SQL, mysqlsh JS, and connection strings the helpers build.
+"""
+
+import json
+
+
+def js_str(value: str) -> str:
+    """Encode a Python string as a JavaScript string literal for mysqlsh --js scripts.
+
+    JSON encoding yields a valid JS string literal with quotes, backslashes, and
+    control/non-ASCII characters escaped, so values like a cluster name or a connection
+    URI (which contains a password) can't break the script or inject.
+    """
+    return json.dumps(value)
+
+
+def sql_str(value: str) -> str:
+    """Quote a MySQL string literal, escaping backslashes and single quotes."""
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def sql_ident(name: str) -> str:
+    """Quote a MySQL identifier (e.g. schema/table), escaping embedded backticks."""
+    return "`" + name.replace("`", "``") + "`"

--- a/test_scripts/ps/group-replication/generic_helper.py
+++ b/test_scripts/ps/group-replication/generic_helper.py
@@ -18,8 +18,14 @@ def js_str(value: str) -> str:
 
 
 def sql_str(value: str) -> str:
-    """Quote a MySQL string literal, escaping backslashes and single quotes."""
-    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+    """Quote a MySQL string literal safely regardless of sql_mode.
+
+    Single quotes are doubled ('') — the ANSI-standard form that works whether or not
+    NO_BACKSLASH_ESCAPES is set (a backslash escape like \\' would break/inject under
+    NO_BACKSLASH_ESCAPES). Backslashes are still doubled so a value ending in one can't
+    escape the closing quote under MySQL's default (backslash-enabled) mode.
+    """
+    return "'" + value.replace("\\", "\\\\").replace("'", "''") + "'"
 
 
 def sql_ident(name: str) -> str:

--- a/test_scripts/ps/group-replication/group_replication.py
+++ b/test_scripts/ps/group-replication/group_replication.py
@@ -1,0 +1,242 @@
+import time
+
+from docker_helper import DockerHelper
+
+
+class GroupReplication:
+    def __init__(
+        self,
+        docker: DockerHelper,
+        num_nodes: int = 3,
+        network: str = "grnet",
+        image: str = "percona/percona-server:8.4",
+        node_prefix: str = "ps",
+        root_password: str = "rootpass",
+        base_host_port: int = 33060,
+        cluster_name: str = "testCluster",
+        group_name: str = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        gr_port: int = 33061,
+        communication_stack: str = "XCOM",
+        single_primary: bool = True,
+        start_on_boot: bool = False,
+        mysql_extra_args: list[str] | None = None,
+    ):
+        if num_nodes < 1:
+            raise ValueError("num_nodes must be >= 1")
+        self.docker = docker
+        self.num_nodes = num_nodes
+        self.network = network
+        self.image = image
+        self.node_prefix = node_prefix
+        self.root_password = root_password
+        self.base_host_port = base_host_port
+        self.cluster_name = cluster_name
+        self.group_name = group_name
+        self.gr_port = gr_port
+        self.communication_stack = communication_stack
+        self.single_primary = single_primary
+        self.start_on_boot = start_on_boot
+        self.mysql_extra_args = list(mysql_extra_args or [])
+        self.containers: list[str] = []
+        self.networks: list[str] = []
+
+    def _gr_address(self, name: str) -> str:
+        return f"{name}:{self.gr_port}"
+
+    def _group_seeds(self) -> str:
+        return ",".join(self._gr_address(self._node_name(i)) for i in range(1, self.num_nodes + 1))
+
+    def _node_name(self, index: int) -> str:
+        return f"{self.node_prefix}{index}"
+
+    def _volume_name(self, index: int) -> str:
+        return f"{self._node_name(index)}-data"
+
+    def _mysqld_args(self, server_id: int, hostname: str) -> list[str]:
+        args = [
+            f"--server-id={server_id}",
+            f"--report-host={hostname}",
+            "--log-bin=binlog",
+            "--enforce-gtid-consistency=ON",
+            "--gtid-mode=ON",
+            "--log-replica-updates=ON",
+            "--binlog-format=ROW",
+            "--plugin-load-add=group_replication.so",
+        ]
+        args.extend(self.mysql_extra_args)
+        return args
+
+    def _wait_ready(self, name: str, timeout: int = 180) -> None:
+        deadline = time.time() + timeout
+        last_err = ""
+        while time.time() < deadline:
+            result = self.docker.exec_command(
+                name, f"mysqladmin -uroot -p{self.root_password} ping --silent"
+            )
+            if result.ok and "mysqld is alive" in result.stdout:
+                return
+            last_err = (result.stderr or result.stdout).strip()
+            time.sleep(2)
+        raise RuntimeError(f"Container {name} did not become ready in {timeout}s. Last: {last_err}")
+
+    def primary(self) -> str:
+        if not self.containers:
+            raise RuntimeError("Cluster not created yet")
+        return self.containers[0]
+
+    def create(self) -> None:
+        self.docker.network_create(self.network)
+        self.networks.append(self.network)
+
+        for i in range(1, self.num_nodes + 1):
+            name = self._node_name(i)
+            self.docker.create(
+                image=self.image,
+                name=name,
+                hostname=name,
+                environment={"MYSQL_ROOT_PASSWORD": self.root_password},
+                volumes=[f"{self._volume_name(i)}:/var/lib/mysql"],
+                networks=[self.network],
+                ports=[f"{self.base_host_port + i}:3306"],
+                command=self._mysqld_args(server_id=i, hostname=name),
+                restart="always",
+            )
+            self.containers.append(name)
+
+        for name in self.containers:
+            self._wait_ready(name)
+
+        primary = self.primary()
+        bootstrap_opts = (
+            f"groupName:'{self.group_name}',"
+            f"communicationStack:'{self.communication_stack}',"
+            f"localAddress:'{self._gr_address(primary)}',"
+            f"multiPrimary:{'false' if self.single_primary else 'true'}"
+        )
+        bootstrap_script = (
+            f"var c = dba.createCluster('{self.cluster_name}', {{{bootstrap_opts}}});"
+        )
+        self.docker.exec_mysqlsh(primary, bootstrap_script)
+
+        for i in range(2, self.num_nodes + 1):
+            node = self._node_name(i)
+            add_script = (
+                f"var c = dba.getCluster('{self.cluster_name}');"
+                f"c.addInstance('root:{self.root_password}@{node}:3306', {{"
+                f"recoveryMethod:'clone',"
+                f"localAddress:'{self._gr_address(node)}'"
+                "});"
+            )
+            self.docker.exec_mysqlsh(primary, add_script)
+
+        status = self.docker.exec_mysqlsh(
+            primary,
+            f"var c = dba.getCluster('{self.cluster_name}'); print(JSON.stringify(c.status()));",
+        )
+        if '"status": "ONLINE"' not in status.stdout and '"status":"ONLINE"' not in status.stdout:
+            raise RuntimeError(
+                f"Cluster did not reach ONLINE state. mysqlsh output:\n{status.stdout}\n{status.stderr}"
+            )
+
+        start_on_boot = "ON" if self.start_on_boot else "OFF"
+        seeds = self._group_seeds()
+        for name in self.containers:
+            self.docker.exec_mysql(
+                name,
+                f"SET PERSIST group_replication_start_on_boot={start_on_boot};"
+                f"SET PERSIST group_replication_group_seeds='{seeds}';",
+            )
+
+    def _read_variables(self, name: str, variables: list[str]) -> dict[str, str]:
+        in_clause = ",".join(f"'{v}'" for v in variables)
+        result = self.docker.exec_mysql(
+            name,
+            f"SHOW GLOBAL VARIABLES WHERE Variable_name IN ({in_clause});",
+        )
+        actual: dict[str, str] = {}
+        for line in result.stdout.strip().splitlines():
+            parts = line.split("\t")
+            if len(parts) >= 2:
+                actual[parts[0]] = parts[1]
+        return actual
+
+    def verify(self) -> None:
+        if not self.containers:
+            raise RuntimeError("Cluster not created yet")
+
+        errors: list[str] = []
+
+        common_expected = {
+            "group_replication_group_name": self.group_name,
+            "group_replication_start_on_boot": "ON" if self.start_on_boot else "OFF",
+            "group_replication_group_seeds": self._group_seeds(),
+            "group_replication_single_primary_mode": "ON" if self.single_primary else "OFF",
+            "gtid_mode": "ON",
+            "enforce_gtid_consistency": "ON",
+        }
+        variables = list(common_expected.keys()) + ["group_replication_local_address"]
+
+        for node in self.containers:
+            actual = self._read_variables(node, variables)
+            for var, expected in common_expected.items():
+                got = actual.get(var)
+                if got != expected:
+                    errors.append(f"{node}: {var}={got!r}, expected {expected!r}")
+            expected_local = self._gr_address(node)
+            got_local = actual.get("group_replication_local_address")
+            if got_local != expected_local:
+                errors.append(
+                    f"{node}: group_replication_local_address={got_local!r}, "
+                    f"expected {expected_local!r}"
+                )
+
+        primary = self.primary()
+        result = self.docker.exec_mysql(
+            primary,
+            "SELECT MEMBER_HOST, MEMBER_PORT, MEMBER_STATE, MEMBER_ROLE "
+            "FROM performance_schema.replication_group_members;",
+        )
+        members: list[tuple[str, str, str, str]] = []
+        for line in result.stdout.strip().splitlines():
+            parts = line.split("\t")
+            if len(parts) >= 4:
+                members.append((parts[0], parts[1], parts[2], parts[3]))
+
+        if len(members) != self.num_nodes:
+            errors.append(
+                f"Expected {self.num_nodes} members in replication_group_members, "
+                f"got {len(members)}: {members}"
+            )
+
+        hosts = sorted(m[0] for m in members)
+        expected_hosts = sorted(self.containers)
+        if hosts != expected_hosts:
+            errors.append(f"Member hosts mismatch: got {hosts}, expected {expected_hosts}")
+
+        bad_state = [m for m in members if m[2] != "ONLINE"]
+        if bad_state:
+            errors.append(f"Members not ONLINE: {bad_state}")
+
+        primaries = [m for m in members if m[3] == "PRIMARY"]
+        secondaries = [m for m in members if m[3] == "SECONDARY"]
+        if self.single_primary:
+            if len(primaries) != 1:
+                errors.append(f"Expected exactly 1 PRIMARY, got {len(primaries)}: {members}")
+            if len(secondaries) != self.num_nodes - 1:
+                errors.append(
+                    f"Expected {self.num_nodes - 1} SECONDARY, got {len(secondaries)}: {members}"
+                )
+
+        if errors:
+            raise AssertionError("GroupReplication.verify failed:\n  " + "\n  ".join(errors))
+
+    def destroy(self, remove_volumes: bool = False) -> None:
+        for name in reversed(self.containers):
+            self.docker.destroy(name)
+        if remove_volumes:
+            for i in range(1, self.num_nodes + 1):
+                self.docker.volume_remove(self._volume_name(i))
+        for net in self.networks:
+            self.docker.network_remove(net)
+        self.containers.clear()
+        self.networks.clear()

--- a/test_scripts/ps/group-replication/group_replication.py
+++ b/test_scripts/ps/group-replication/group_replication.py
@@ -230,6 +230,55 @@ class GroupReplication:
         if errors:
             raise AssertionError("GroupReplication.verify failed:\n  " + "\n  ".join(errors))
 
+    def _list_tables(self, node: str, database: str) -> list[str]:
+        result = self.docker.exec_mysql(
+            node,
+            "SELECT TABLE_NAME FROM information_schema.TABLES "
+            f"WHERE TABLE_SCHEMA='{database}' AND TABLE_TYPE='BASE TABLE' "
+            "ORDER BY TABLE_NAME;",
+        )
+        return [line.strip() for line in result.stdout.strip().splitlines() if line.strip()]
+
+    def _table_checksum(self, node: str, database: str, table: str) -> str:
+        result = self.docker.exec_mysql(
+            node, f"CHECKSUM TABLE `{database}`.`{table}`;"
+        )
+        # Output is "<database>.<table>\t<checksum>" (or NULL if the table is missing).
+        parts = result.stdout.strip().split("\t")
+        return parts[-1] if parts else ""
+
+    def verify_checksums(self, database: str, timeout: int = 30) -> dict[str, str]:
+        if not self.containers:
+            raise RuntimeError("Cluster not created yet")
+
+        tables = self._list_tables(self.primary(), database)
+        if not tables:
+            raise AssertionError(f"No base tables found in database {database!r}")
+
+        # Secondaries apply transactions asynchronously, so a checksum taken right
+        # after a write can briefly differ. Retry until everything agrees or we time out.
+        deadline = time.time() + timeout
+        while True:
+            errors: list[str] = []
+            checksums: dict[str, str] = {}
+            for table in tables:
+                per_node = {
+                    node: self._table_checksum(node, database, table)
+                    for node in self.containers
+                }
+                if len(set(per_node.values())) != 1:
+                    errors.append(f"{database}.{table} checksum mismatch: {per_node}")
+                else:
+                    checksums[table] = next(iter(per_node.values()))
+
+            if not errors:
+                return checksums
+            if time.time() >= deadline:
+                raise AssertionError(
+                    "GroupReplication.verify_checksums failed:\n  " + "\n  ".join(errors)
+                )
+            time.sleep(1)
+
     def destroy(self, remove_volumes: bool = False) -> None:
         for name in reversed(self.containers):
             self.docker.destroy(name)

--- a/test_scripts/ps/group-replication/group_replication.py
+++ b/test_scripts/ps/group-replication/group_replication.py
@@ -1,6 +1,10 @@
+import logging
+import os
 import time
 
 from docker_helper import DockerHelper
+
+_logger = logging.getLogger("GR")
 
 
 class GroupReplication:
@@ -20,9 +24,13 @@ class GroupReplication:
         single_primary: bool = True,
         start_on_boot: bool = False,
         mysql_extra_args: list[str] | None = None,
+        verbose: bool | None = None,
     ):
         if num_nodes < 1:
             raise ValueError("num_nodes must be >= 1")
+        if verbose is None:
+            verbose = os.environ.get("GR_VERBOSE", "").lower() in ("1", "true", "yes", "on")
+        self.verbose = verbose
         self.docker = docker
         self.num_nodes = num_nodes
         self.network = network
@@ -39,6 +47,10 @@ class GroupReplication:
         self.mysql_extra_args = list(mysql_extra_args or [])
         self.containers: list[str] = []
         self.networks: list[str] = []
+
+    def log(self, msg: str) -> None:
+        if self.verbose:
+            _logger.info(msg)
 
     def _gr_address(self, name: str) -> str:
         return f"{name}:{self.gr_port}"
@@ -67,6 +79,7 @@ class GroupReplication:
         return args
 
     def _wait_ready(self, name: str, timeout: int = 180) -> None:
+        self.log(f"wait for {name} to accept connections")
         deadline = time.time() + timeout
         last_err = ""
         while time.time() < deadline:
@@ -85,11 +98,13 @@ class GroupReplication:
         return self.containers[0]
 
     def create(self) -> None:
+        self.log(f"create network {self.network}")
         self.docker.network_create(self.network)
         self.networks.append(self.network)
 
         for i in range(1, self.num_nodes + 1):
             name = self._node_name(i)
+            self.log(f"start node {name} (server-id={i}, {self.base_host_port + i}->3306)")
             self.docker.create(
                 image=self.image,
                 name=name,
@@ -116,10 +131,12 @@ class GroupReplication:
         bootstrap_script = (
             f"var c = dba.createCluster('{self.cluster_name}', {{{bootstrap_opts}}});"
         )
+        self.log(f"bootstrap cluster on {primary}")
         self.docker.exec_mysqlsh(primary, bootstrap_script)
 
         for i in range(2, self.num_nodes + 1):
             node = self._node_name(i)
+            self.log(f"add {node} to cluster (clone)")
             add_script = (
                 f"var c = dba.getCluster('{self.cluster_name}');"
                 f"c.addInstance('root:{self.root_password}@{node}:3306', {{"
@@ -137,9 +154,11 @@ class GroupReplication:
             raise RuntimeError(
                 f"Cluster did not reach ONLINE state. mysqlsh output:\n{status.stdout}\n{status.stderr}"
             )
+        self.log("cluster is ONLINE")
 
         start_on_boot = "ON" if self.start_on_boot else "OFF"
         seeds = self._group_seeds()
+        self.log("persist GR settings (start_on_boot, group_seeds) on each node")
         for name in self.containers:
             self.docker.exec_mysql(
                 name,
@@ -176,6 +195,7 @@ class GroupReplication:
         }
         variables = list(common_expected.keys()) + ["group_replication_local_address"]
 
+        self.log("verify GR variables on each node")
         for node in self.containers:
             actual = self._read_variables(node, variables)
             for var, expected in common_expected.items():
@@ -191,6 +211,7 @@ class GroupReplication:
                 )
 
         primary = self.primary()
+        self.log("check membership via replication_group_members")
         result = self.docker.exec_mysql(
             primary,
             "SELECT MEMBER_HOST, MEMBER_PORT, MEMBER_STATE, MEMBER_ROLE "
@@ -251,6 +272,7 @@ class GroupReplication:
         if not self.containers:
             raise RuntimeError("Cluster not created yet")
 
+        self.log(f"list tables in {database}")
         tables = self._list_tables(self.primary(), database)
         if not tables:
             raise AssertionError(f"No base tables found in database {database!r}")
@@ -258,10 +280,13 @@ class GroupReplication:
         # Secondaries apply transactions asynchronously, so a checksum taken right
         # after a write can briefly differ. Retry until everything agrees or we time out.
         deadline = time.time() + timeout
+        first_pass = True
         while True:
             errors: list[str] = []
             checksums: dict[str, str] = {}
             for table in tables:
+                if first_pass:
+                    self.log(f"compare checksum {database}.{table} across nodes")
                 per_node = {
                     node: self._table_checksum(node, database, table)
                     for node in self.containers
@@ -277,9 +302,11 @@ class GroupReplication:
                 raise AssertionError(
                     "GroupReplication.verify_checksums failed:\n  " + "\n  ".join(errors)
                 )
+            first_pass = False
             time.sleep(1)
 
     def destroy(self, remove_volumes: bool = False) -> None:
+        self.log("destroy cluster")
         for name in reversed(self.containers):
             self.docker.destroy(name)
         if remove_volumes:

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -537,8 +537,8 @@ class GroupReplication:
     def wait_proxy_ready(self, timeout: int = 120) -> None:
         """Wait until the proxy accepts connections and routes the read/write endpoint to the current primary.
 
-        The default is generous because HAProxy's external health checks can take tens of seconds to
-        first stabilize when the operator image runs under CPU emulation.
+        The default is generous because HAProxy health checks can take tens of seconds to first stabilize when
+        the operator image runs under CPU emulation.
         """
         if not self.proxy:
             return

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -13,7 +13,7 @@ class GroupReplication:
         docker: DockerHelper,
         num_nodes: int = 3,
         network: str = "grnet",
-        image: str = "percona/percona-server:8.4",
+        server_image: str = "percona/percona-server:8.4",
         node_prefix: str = "ps",
         root_password: str = "rootpass",
         base_host_port: int = 33060,
@@ -44,7 +44,7 @@ class GroupReplication:
         self.docker = docker
         self.num_nodes = num_nodes
         self.network = network
-        self.image = image
+        self.server_image = server_image
         self.node_prefix = node_prefix
         self.root_password = root_password
         self.base_host_port = base_host_port
@@ -514,7 +514,7 @@ class GroupReplication:
         name = self._node_name(index)
         self.log(f"start node {name} (server-id={index}, {self.base_host_port + index}->3306)")
         self.docker.create(
-            image=self.image,
+            image=self.server_image,
             name=name,
             hostname=name,
             environment={"MYSQL_ROOT_PASSWORD": self.root_password},
@@ -539,7 +539,7 @@ class GroupReplication:
         """
         self.log(f"start standalone node {name} (restored data, GR off)")
         self.docker.create(
-            image=self.image,
+            image=self.server_image,
             name=name,
             hostname=name,
             volumes=[f"{data_volume}:/var/lib/mysql"],

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -104,6 +104,16 @@ class GroupReplication:
         """
         return json.dumps(value)
 
+    @staticmethod
+    def _sql_str(value: str) -> str:
+        """Quote a MySQL string literal, escaping backslashes and single quotes."""
+        return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+    @staticmethod
+    def _sql_ident(name: str) -> str:
+        """Quote a MySQL identifier (e.g. schema/table), escaping embedded backticks."""
+        return "`" + name.replace("`", "``") + "`"
+
     def _instance_uri(self, node: str) -> str:
         """Build the AdminAPI connection URI for a node, percent-encoding the credentials.
 
@@ -794,7 +804,7 @@ class GroupReplication:
         result = self.docker.exec_mysql(
             node,
             "SELECT TABLE_NAME FROM information_schema.TABLES "
-            f"WHERE TABLE_SCHEMA='{database}' AND TABLE_TYPE='BASE TABLE' "
+            f"WHERE TABLE_SCHEMA={self._sql_str(database)} AND TABLE_TYPE='BASE TABLE' "
             "ORDER BY TABLE_NAME;",
             password=self.root_password,
         )
@@ -803,7 +813,9 @@ class GroupReplication:
     def _table_checksum(self, node: str, database: str, table: str) -> str:
         """Return the CHECKSUM TABLE value for a single table on the given node."""
         result = self.docker.exec_mysql(
-            node, f"CHECKSUM TABLE `{database}`.`{table}`;", password=self.root_password
+            node,
+            f"CHECKSUM TABLE {self._sql_ident(database)}.{self._sql_ident(table)};",
+            password=self.root_password,
         )
         # Output is "<database>.<table>\t<checksum>" (or NULL if the table is missing).
         parts = result.stdout.strip().split("\t")

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import shlex
@@ -6,6 +5,7 @@ import time
 from urllib.parse import quote
 
 from docker_helper import DockerHelper
+from generic_helper import js_str, sql_ident, sql_str
 
 _logger = logging.getLogger("GR")
 
@@ -99,26 +99,6 @@ class GroupReplication:
         """Build the GR communication address (host:gr_port) for a node."""
         return f"{name}:{self.gr_port}"
 
-    @staticmethod
-    def _js_str(value: str) -> str:
-        """Encode a Python string as a JavaScript string literal for mysqlsh --js scripts.
-
-        JSON encoding yields a valid JS string literal with quotes, backslashes, and
-        control/non-ASCII characters escaped, so values like cluster_name or the
-        connection URI (which contains root_password) can't break the script or inject.
-        """
-        return json.dumps(value)
-
-    @staticmethod
-    def _sql_str(value: str) -> str:
-        """Quote a MySQL string literal, escaping backslashes and single quotes."""
-        return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
-
-    @staticmethod
-    def _sql_ident(name: str) -> str:
-        """Quote a MySQL identifier (e.g. schema/table), escaping embedded backticks."""
-        return "`" + name.replace("`", "``") + "`"
-
     def _instance_uri(self, node: str) -> str:
         """Build the AdminAPI connection URI for a node, percent-encoding the credentials.
 
@@ -131,10 +111,10 @@ class GroupReplication:
     def _add_instance_script(self, node: str) -> str:
         """Build the mysqlsh AdminAPI script to add a node to the cluster (clone recovery)."""
         return (
-            f"var c = dba.getCluster({self._js_str(self.cluster_name)});"
-            f"c.addInstance({self._js_str(self._instance_uri(node))}, {{"
+            f"var c = dba.getCluster({js_str(self.cluster_name)});"
+            f"c.addInstance({js_str(self._instance_uri(node))}, {{"
             f"recoveryMethod:'clone',"
-            f"localAddress:{self._js_str(self._gr_address(node))}"
+            f"localAddress:{js_str(self._gr_address(node))}"
             "});"
         )
 
@@ -334,8 +314,8 @@ class GroupReplication:
         for node in to_remove:
             self.log(f"remove {node} from cluster")
             remove_script = (
-                f"var c = dba.getCluster({self._js_str(self.cluster_name)});"
-                f"c.removeInstance({self._js_str(self._instance_uri(node))});"
+                f"var c = dba.getCluster({js_str(self.cluster_name)});"
+                f"c.removeInstance({js_str(self._instance_uri(node))});"
             )
             self.docker.exec_mysqlsh(primary, remove_script, password=self.root_password)
             self.docker.destroy(node)
@@ -641,13 +621,13 @@ class GroupReplication:
 
         bootstrap_node = self.get_bootstrap_node()
         bootstrap_opts = (
-            f"groupName:{self._js_str(self.group_name)},"
-            f"communicationStack:{self._js_str(self.communication_stack)},"
-            f"localAddress:{self._js_str(self._gr_address(bootstrap_node))},"
+            f"groupName:{js_str(self.group_name)},"
+            f"communicationStack:{js_str(self.communication_stack)},"
+            f"localAddress:{js_str(self._gr_address(bootstrap_node))},"
             f"multiPrimary:{'false' if self.single_primary else 'true'}"
         )
         bootstrap_script = (
-            f"var c = dba.createCluster({self._js_str(self.cluster_name)}, {{{bootstrap_opts}}});"
+            f"var c = dba.createCluster({js_str(self.cluster_name)}, {{{bootstrap_opts}}});"
         )
         self.log(f"bootstrap cluster on {bootstrap_node}")
         self.docker.exec_mysqlsh(bootstrap_node, bootstrap_script, password=self.root_password)
@@ -809,7 +789,7 @@ class GroupReplication:
         result = self.docker.exec_mysql(
             node,
             "SELECT TABLE_NAME FROM information_schema.TABLES "
-            f"WHERE TABLE_SCHEMA={self._sql_str(database)} AND TABLE_TYPE='BASE TABLE' "
+            f"WHERE TABLE_SCHEMA={sql_str(database)} AND TABLE_TYPE='BASE TABLE' "
             "ORDER BY TABLE_NAME;",
             password=self.root_password,
         )
@@ -819,7 +799,7 @@ class GroupReplication:
         """Return the CHECKSUM TABLE value for a single table on the given node."""
         result = self.docker.exec_mysql(
             node,
-            f"CHECKSUM TABLE {self._sql_ident(database)}.{self._sql_ident(table)};",
+            f"CHECKSUM TABLE {sql_ident(database)}.{sql_ident(table)};",
             password=self.root_password,
         )
         # Output is "<database>.<table>\t<checksum>" (or NULL if the table is missing).

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -307,15 +307,19 @@ class GroupReplication:
             return (self.haproxy_name, self.haproxy_write_port)
         return (self.get_primary(), 3306)
 
+    def secondaries(self) -> list[str]:
+        """Return the active secondary node names (every active node except the current primary)."""
+        primary = self.get_primary()
+        return [n for n in self.active_nodes if n != primary]
+
     def ro_endpoint(self) -> tuple[str, int]:
         """Return the (host, port) for read-only traffic: the proxy when enabled, else an active secondary."""
         if self.proxy == "router":
             return (self.router_name, self.router_ro_port)
         if self.proxy == "haproxy":
             return (self.haproxy_name, self.haproxy_read_port)
-        primary = self.get_primary()
-        secondaries = [n for n in self.active_nodes if n != primary]
-        return ((secondaries[0] if secondaries else primary), 3306)
+        secondaries = self.secondaries()
+        return ((secondaries[0] if secondaries else self.get_primary()), 3306)
 
     def exec_sql(self, sql: str, database: str | None = None, check: bool = True):
         """Run application SQL through the read/write endpoint (via the proxy when enabled, else direct to the primary)."""
@@ -527,6 +531,28 @@ class GroupReplication:
         self.node_index[name] = index
         return name
 
+    def start_standalone_node(self, name: str, data_volume: str, server_id: int = 99) -> str:
+        """Start a standalone PS container on a pre-populated (e.g. restored) data volume.
+
+        The node is NOT attached to the cluster network and group replication is kept off
+        (--group-replication-start-on-boot=OFF overrides the persisted ON), so it never
+        contacts the live group. The GR plugin is still loaded, so the datadir's persisted
+        group_replication_* variables remain valid. Useful for inspecting restored data in
+        isolation. Returns the container name; it is not tracked in self.containers.
+        """
+        self.log(f"start standalone node {name} (restored data, GR off)")
+        self.docker.create(
+            image=self.image,
+            name=name,
+            hostname=name,
+            volumes=[f"{data_volume}:/var/lib/mysql"],
+            command=self._mysqld_args(server_id=server_id, hostname=name)
+            + ["--group-replication-start-on-boot=OFF"],
+            restart="on-failure",
+        )
+        self._wait_ready(name)
+        return name
+
     def create(self) -> None:
         """Create the network and nodes, bootstrap the cluster, add instances, and persist GR settings."""
         self.log(f"create network {self.network}")
@@ -714,6 +740,13 @@ class GroupReplication:
         # Output is "<database>.<table>\t<checksum>" (or NULL if the table is missing).
         parts = result.stdout.strip().split("\t")
         return parts[-1] if parts else ""
+
+    def table_checksums(self, node: str, database: str) -> dict[str, str]:
+        """Return the CHECKSUM TABLE value of every base table in a database on one node."""
+        tables = self._list_tables(node, database)
+        if not tables:
+            raise AssertionError(f"No base tables found in database {database!r} on {node}")
+        return {table: self._table_checksum(node, database, table) for table in tables}
 
     def verify_checksums(
         self, database: str, nodes: list[str] | None = None, timeout: int = 30

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -230,7 +230,7 @@ class GroupReplication:
             raise RuntimeError("Cluster not created yet")
         if count < 1:
             raise ValueError("count must be >= 1")
-        primary = self.primary()
+        primary = self.get_primary()
         added: list[str] = []
         next_index = max(self.node_index.values())
         for _ in range(count):

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -460,7 +460,9 @@ class GroupReplication:
         """Pin the write backend to the given primary: mark it ready and every other node in maintenance.
 
         Uses HAProxy's runtime API over the stats socket, so writes only reach the primary even though
-        mysql-check alone cannot distinguish it. Errors are ignored (e.g. before the socket is up).
+        mysql-check alone cannot distinguish it. Failures are not raised (this is polled before the
+        socket is up), but they're logged in verbose mode so routing problems (missing socat, wrong
+        socket path, permissions, or a rejected command) are diagnosable.
         """
         # HAProxy's runtime API is line-oriented: one command per line, each terminated
         # by a newline. Joining with ';' would be sent as a single command and ignored.
@@ -468,11 +470,18 @@ class GroupReplication:
             f"set server be_write/{n} state {'ready' if n == primary else 'maint'}\n"
             for n in self.containers
         )
-        self.docker.exec_command(
+        result = self.docker.exec_command(
             self.haproxy_name,
             f"printf '%s' '{cmds}' | socat - UNIX-CONNECT:/tmp/haproxy.sock",
             check=False,
         )
+        # A successful "set server" prints nothing; any non-zero exit or output indicates
+        # a socket/socat problem or an HAProxy-rejected command worth surfacing.
+        if not result.ok or result.stdout.strip() or result.stderr.strip():
+            self.log(
+                f"HAProxy runtime API (pin write -> {primary}) exit={result.returncode} "
+                f"stdout={result.stdout.strip()!r} stderr={result.stderr.strip()!r}"
+            )
 
     def _start_haproxy(self) -> None:
         """Start a Percona HAProxy container fronting the cluster (write :3307, read :3308).

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -22,7 +22,7 @@ class GroupReplication:
         gr_port: int = 33061,
         communication_stack: str = "XCOM",
         single_primary: bool = True,
-        start_on_boot: bool = False,
+        start_on_boot: bool = True,
         mysql_extra_args: list[str] | None = None,
         verbose: bool | None = None,
     ):
@@ -46,6 +46,7 @@ class GroupReplication:
         self.start_on_boot = start_on_boot
         self.mysql_extra_args = list(mysql_extra_args or [])
         self.containers: list[str] = []
+        self.active_nodes: list[str] = []
         self.networks: list[str] = []
 
     def log(self, msg: str) -> None:
@@ -97,6 +98,67 @@ class GroupReplication:
             raise RuntimeError("Cluster not created yet")
         return self.containers[0]
 
+    def get_primary(self, timeout: int = 60) -> str:
+        if not self.active_nodes:
+            raise RuntimeError("No active nodes")
+        deadline = time.time() + timeout
+        last = ""
+        while time.time() < deadline:
+            node = self.active_nodes[0]
+            result = self.docker.exec_mysql(
+                node,
+                "SELECT MEMBER_HOST FROM performance_schema.replication_group_members "
+                "WHERE MEMBER_ROLE='PRIMARY' AND MEMBER_STATE='ONLINE';",
+                check=False,
+            )
+            host = result.stdout.strip()
+            if result.ok and host and "\n" not in host:
+                return host
+            last = host or (result.stderr or "").strip()
+            time.sleep(2)
+        raise RuntimeError(f"No PRIMARY elected within {timeout}s (last: {last!r})")
+
+    def stop_node(self, name: str) -> None:
+        self.log(f"stop node {name}")
+        self.docker.stop(name)
+        if name in self.active_nodes:
+            self.active_nodes.remove(name)
+
+    def _member_states(self, node: str) -> dict[str, str]:
+        result = self.docker.exec_mysql(
+            node,
+            "SELECT MEMBER_HOST, MEMBER_STATE "
+            "FROM performance_schema.replication_group_members;",
+            check=False,
+        )
+        states: dict[str, str] = {}
+        if result.ok:
+            for line in result.stdout.strip().splitlines():
+                parts = line.split("\t")
+                if len(parts) >= 2:
+                    states[parts[0]] = parts[1]
+        return states
+
+    def wait_all_online(self, timeout: int = 180) -> None:
+        self.log("wait for all members ONLINE")
+        deadline = time.time() + timeout
+        last: dict[str, str] = {}
+        while time.time() < deadline:
+            states = self._member_states(self.active_nodes[0])
+            last = states
+            if len(states) == self.num_nodes and all(s == "ONLINE" for s in states.values()):
+                return
+            time.sleep(2)
+        raise RuntimeError(f"Not all members ONLINE within {timeout}s (last: {last})")
+
+    def rejoin_node(self, name: str, timeout: int = 180) -> None:
+        self.log(f"start node {name} (auto-rejoin)")
+        self.docker.start(name)
+        self._wait_ready(name)
+        if name not in self.active_nodes:
+            self.active_nodes.append(name)
+        self.wait_all_online(timeout=timeout)
+
     def create(self) -> None:
         self.log(f"create network {self.network}")
         self.docker.network_create(self.network)
@@ -117,6 +179,8 @@ class GroupReplication:
                 restart="always",
             )
             self.containers.append(name)
+
+        self.active_nodes = list(self.containers)
 
         for name in self.containers:
             self._wait_ready(name)
@@ -268,12 +332,17 @@ class GroupReplication:
         parts = result.stdout.strip().split("\t")
         return parts[-1] if parts else ""
 
-    def verify_checksums(self, database: str, timeout: int = 30) -> dict[str, str]:
+    def verify_checksums(
+        self, database: str, nodes: list[str] | None = None, timeout: int = 30
+    ) -> dict[str, str]:
         if not self.containers:
             raise RuntimeError("Cluster not created yet")
+        nodes = nodes if nodes is not None else self.active_nodes
+        if not nodes:
+            raise RuntimeError("No nodes to compare")
 
         self.log(f"list tables in {database}")
-        tables = self._list_tables(self.primary(), database)
+        tables = self._list_tables(nodes[0], database)
         if not tables:
             raise AssertionError(f"No base tables found in database {database!r}")
 
@@ -289,7 +358,7 @@ class GroupReplication:
                     self.log(f"compare checksum {database}.{table} across nodes")
                 per_node = {
                     node: self._table_checksum(node, database, table)
-                    for node in self.containers
+                    for node in nodes
                 }
                 if len(set(per_node.values())) != 1:
                     errors.append(f"{database}.{table} checksum mismatch: {per_node}")
@@ -315,4 +384,5 @@ class GroupReplication:
         for net in self.networks:
             self.docker.network_remove(net)
         self.containers.clear()
+        self.active_nodes.clear()
         self.networks.clear()

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -767,6 +767,10 @@ class GroupReplication:
         if check_proxy and self.proxy:
             self.log(f"verify {self.proxy} routes read/write traffic to the primary")
             host, port = self.rw_endpoint()
+            # Capture the primary once (a failover between the check and the message could
+            # otherwise disagree) and bound the proxy probe with a timeout so a misbehaving
+            # proxy can't hang the run until an outer pytest timeout.
+            primary = self.get_primary()
             result = self.docker.exec_mysql(
                 self.active_nodes[0],
                 "SELECT @@hostname;",
@@ -774,11 +778,12 @@ class GroupReplication:
                 host=host,
                 port=port,
                 check=False,
+                timeout=15,
             )
             routed = result.stdout.strip()
-            if not result.ok or routed != self.get_primary():
+            if not result.ok or routed != primary:
                 errors.append(
-                    f"{self.proxy} RW endpoint routes to {routed!r}, expected primary {self.get_primary()!r}"
+                    f"{self.proxy} RW endpoint routes to {routed!r}, expected primary {primary!r}"
                 )
 
         if errors:

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -558,6 +558,9 @@ class GroupReplication:
 
         primaries = [m for m in members if m[3] == "PRIMARY"]
         secondaries = [m for m in members if m[3] == "SECONDARY"]
+        primary_hosts = ", ".join(sorted(m[0] for m in primaries)) or "none"
+        secondary_hosts = ", ".join(sorted(m[0] for m in secondaries)) or "none"
+        self.log(f"primary: {primary_hosts}; secondaries: {secondary_hosts}")
         if self.single_primary:
             if len(primaries) != 1:
                 errors.append(f"Expected exactly 1 PRIMARY, got {len(primaries)}: {members}")

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -50,22 +50,28 @@ class GroupReplication:
         self.networks: list[str] = []
 
     def log(self, msg: str) -> None:
+        """Log a message, but only when verbose mode is enabled."""
         if self.verbose:
             _logger.info(msg)
 
     def _gr_address(self, name: str) -> str:
+        """Build the GR communication address (host:gr_port) for a node."""
         return f"{name}:{self.gr_port}"
 
     def _group_seeds(self) -> str:
+        """Build the comma-separated group_replication_group_seeds list for all nodes."""
         return ",".join(self._gr_address(self._node_name(i)) for i in range(1, self.num_nodes + 1))
 
     def _node_name(self, index: int) -> str:
+        """Build the container/host name for the node at the given 1-based index."""
         return f"{self.node_prefix}{index}"
 
     def _volume_name(self, index: int) -> str:
+        """Build the data volume name for the node at the given 1-based index."""
         return f"{self._node_name(index)}-data"
 
     def _mysqld_args(self, server_id: int, hostname: str) -> list[str]:
+        """Build the mysqld command-line arguments required for Group Replication on a node."""
         args = [
             f"--server-id={server_id}",
             f"--report-host={hostname}",
@@ -80,6 +86,7 @@ class GroupReplication:
         return args
 
     def _wait_ready(self, name: str, timeout: int = 180) -> None:
+        """Wait until a node accepts MySQL connections (responds to ping), or time out."""
         self.log(f"wait for {name} to accept connections")
         deadline = time.time() + timeout
         last_err = ""
@@ -94,11 +101,13 @@ class GroupReplication:
         raise RuntimeError(f"Container {name} did not become ready in {timeout}s. Last: {last_err}")
 
     def primary(self) -> str:
+        """Return the bootstrap node name (the first container created)."""
         if not self.containers:
             raise RuntimeError("Cluster not created yet")
         return self.containers[0]
 
     def get_primary(self, timeout: int = 60) -> str:
+        """Query the cluster for the host of the currently elected ONLINE PRIMARY, or time out."""
         if not self.active_nodes:
             raise RuntimeError("No active nodes")
         deadline = time.time() + timeout
@@ -119,12 +128,14 @@ class GroupReplication:
         raise RuntimeError(f"No PRIMARY elected within {timeout}s (last: {last!r})")
 
     def stop_node(self, name: str) -> None:
+        """Stop a node's container and remove it from the active-nodes list."""
         self.log(f"stop node {name}")
         self.docker.stop(name)
         if name in self.active_nodes:
             self.active_nodes.remove(name)
 
     def _member_states(self, node: str) -> dict[str, str]:
+        """Read the host->state map of all group members as seen from the given node."""
         result = self.docker.exec_mysql(
             node,
             "SELECT MEMBER_HOST, MEMBER_STATE "
@@ -140,6 +151,7 @@ class GroupReplication:
         return states
 
     def wait_all_online(self, timeout: int = 180) -> None:
+        """Wait until every expected member reports the ONLINE state, or time out."""
         self.log("wait for all members ONLINE")
         deadline = time.time() + timeout
         last: dict[str, str] = {}
@@ -152,6 +164,7 @@ class GroupReplication:
         raise RuntimeError(f"Not all members ONLINE within {timeout}s (last: {last})")
 
     def rejoin_node(self, name: str, timeout: int = 180) -> None:
+        """Restart a stopped node and wait for it to auto-rejoin and all members to be ONLINE."""
         self.log(f"start node {name} (auto-rejoin)")
         self.docker.start(name)
         self._wait_ready(name)
@@ -160,6 +173,7 @@ class GroupReplication:
         self.wait_all_online(timeout=timeout)
 
     def create(self) -> None:
+        """Create the network and nodes, bootstrap the cluster, add instances, and persist GR settings."""
         self.log(f"create network {self.network}")
         self.docker.network_create(self.network)
         self.networks.append(self.network)
@@ -231,6 +245,7 @@ class GroupReplication:
             )
 
     def _read_variables(self, name: str, variables: list[str]) -> dict[str, str]:
+        """Read the given global variables from a node as a name->value map."""
         in_clause = ",".join(f"'{v}'" for v in variables)
         result = self.docker.exec_mysql(
             name,
@@ -244,6 +259,7 @@ class GroupReplication:
         return actual
 
     def verify(self) -> None:
+        """Assert that GR variables, membership, states, and roles match the expected configuration."""
         if not self.containers:
             raise RuntimeError("Cluster not created yet")
 
@@ -316,6 +332,7 @@ class GroupReplication:
             raise AssertionError("GroupReplication.verify failed:\n  " + "\n  ".join(errors))
 
     def _list_tables(self, node: str, database: str) -> list[str]:
+        """List the base table names in a database on the given node."""
         result = self.docker.exec_mysql(
             node,
             "SELECT TABLE_NAME FROM information_schema.TABLES "
@@ -325,6 +342,7 @@ class GroupReplication:
         return [line.strip() for line in result.stdout.strip().splitlines() if line.strip()]
 
     def _table_checksum(self, node: str, database: str, table: str) -> str:
+        """Return the CHECKSUM TABLE value for a single table on the given node."""
         result = self.docker.exec_mysql(
             node, f"CHECKSUM TABLE `{database}`.`{table}`;"
         )
@@ -335,6 +353,7 @@ class GroupReplication:
     def verify_checksums(
         self, database: str, nodes: list[str] | None = None, timeout: int = 30
     ) -> dict[str, str]:
+        """Compare per-table checksums across nodes (retrying for replication lag) and return them."""
         if not self.containers:
             raise RuntimeError("Cluster not created yet")
         nodes = nodes if nodes is not None else self.active_nodes
@@ -375,6 +394,7 @@ class GroupReplication:
             time.sleep(1)
 
     def destroy(self, remove_volumes: bool = False) -> None:
+        """Remove all containers, optionally their data volumes, and the networks, then reset state."""
         self.log("destroy cluster")
         for name in reversed(self.containers):
             self.docker.destroy(name)

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -23,6 +23,10 @@ class GroupReplication:
         communication_stack: str = "XCOM",
         single_primary: bool = True,
         start_on_boot: bool = True,
+        mysql_router: bool = False,
+        router_image: str = "percona/percona-mysql-router:8.4",
+        router_rw_port: int = 6446,
+        router_ro_port: int = 6447,
         mysql_extra_args: list[str] | None = None,
         verbose: bool | None = None,
     ):
@@ -44,6 +48,12 @@ class GroupReplication:
         self.communication_stack = communication_stack
         self.single_primary = single_primary
         self.start_on_boot = start_on_boot
+        self.mysql_router = mysql_router
+        self.router_image = router_image
+        self.router_name = f"{node_prefix}router"
+        self.router_rw_port = router_rw_port
+        self.router_ro_port = router_ro_port
+        self._router_started = False
         self.mysql_extra_args = list(mysql_extra_args or [])
         self.containers: list[str] = []
         self.active_nodes: list[str] = []
@@ -172,6 +182,84 @@ class GroupReplication:
             self.active_nodes.append(name)
         self.wait_all_online(timeout=timeout)
 
+    def rw_endpoint(self) -> tuple[str, int]:
+        """Return the (host, port) for read/write traffic: the router when enabled, else the live primary."""
+        if self.mysql_router:
+            return (self.router_name, self.router_rw_port)
+        return (self.get_primary(), 3306)
+
+    def ro_endpoint(self) -> tuple[str, int]:
+        """Return the (host, port) for read-only traffic: the router when enabled, else an active secondary."""
+        if self.mysql_router:
+            return (self.router_name, self.router_ro_port)
+        primary = self.get_primary()
+        secondaries = [n for n in self.active_nodes if n != primary]
+        return ((secondaries[0] if secondaries else primary), 3306)
+
+    def exec_sql(self, sql: str, database: str | None = None, check: bool = True):
+        """Run application SQL through the read/write endpoint (via the router when enabled, else direct to the primary)."""
+        if self.mysql_router:
+            return self.docker.exec_mysql(
+                self.active_nodes[0],
+                sql,
+                database=database,
+                host=self.router_name,
+                port=self.router_rw_port,
+                check=check,
+            )
+        return self.docker.exec_mysql(self.get_primary(), sql, database=database, check=check)
+
+    def _start_router(self) -> None:
+        """Start a MySQL Router container, bootstrapping it against the live InnoDB Cluster.
+
+        We override the image entrypoint and bootstrap explicitly: the Percona router image's
+        own (non-Kubernetes) entrypoint binds the routing ports to localhost, which is
+        unreachable from other containers. --conf-bind-address=0.0.0.0 fixes that, and we run
+        as the image's non-root user (no --user privilege drop).
+        """
+        seed = self.active_nodes[0]
+        self.log(f"start MySQL Router {self.router_name} (bootstrap from {seed})")
+        bootstrap = (
+            f"mysqlrouter --bootstrap root:{self.root_password}@{seed}:3306 "
+            "--directory /tmp/mysqlrouter "
+            "--conf-set-option=DEFAULT.unknown_config_option=warning "
+            "--conf-bind-address=0.0.0.0 --force "
+            "&& exec mysqlrouter -c /tmp/mysqlrouter/mysqlrouter.conf"
+        )
+        self.docker.create(
+            image=self.router_image,
+            name=self.router_name,
+            hostname=self.router_name,
+            networks=[self.network],
+            ports=[
+                f"{self.base_host_port + 90}:{self.router_rw_port}",
+                f"{self.base_host_port + 91}:{self.router_ro_port}",
+            ],
+            entrypoint="bash",
+            command=["-c", bootstrap],
+            restart="on-failure",
+        )
+
+    def _wait_router_ready(self, timeout: int = 60) -> None:
+        """Wait until the router accepts connections and routes the read/write port to the current primary."""
+        self.log(f"wait for router {self.router_name} to route to the primary")
+        deadline = time.time() + timeout
+        last = ""
+        while time.time() < deadline:
+            result = self.docker.exec_mysql(
+                self.active_nodes[0],
+                "SELECT @@hostname;",
+                host=self.router_name,
+                port=self.router_rw_port,
+                check=False,
+            )
+            routed = result.stdout.strip()
+            if result.ok and routed and routed == self.get_primary():
+                return
+            last = routed or (result.stderr or "").strip()
+            time.sleep(2)
+        raise RuntimeError(f"Router {self.router_name} not ready / not routing to primary in {timeout}s (last: {last!r})")
+
     def create(self) -> None:
         """Create the network and nodes, bootstrap the cluster, add instances, and persist GR settings."""
         self.log(f"create network {self.network}")
@@ -244,6 +332,11 @@ class GroupReplication:
                 f"SET PERSIST group_replication_group_seeds='{seeds}';",
             )
 
+        if self.mysql_router:
+            self._start_router()
+            self._router_started = True
+            self._wait_router_ready()
+
     def _read_variables(self, name: str, variables: list[str]) -> dict[str, str]:
         """Read the given global variables from a node as a name->value map."""
         in_clause = ",".join(f"'{v}'" for v in variables)
@@ -258,10 +351,16 @@ class GroupReplication:
                 actual[parts[0]] = parts[1]
         return actual
 
-    def verify(self) -> None:
-        """Assert that GR variables, membership, states, and roles match the expected configuration."""
+    def verify(self, check_router: bool | None = None) -> None:
+        """Assert that GR variables, membership, states, and roles match the expected configuration.
+
+        When check_router is set (defaults to whether the router is enabled), also assert that the
+        router's read/write endpoint routes to the current primary.
+        """
         if not self.containers:
             raise RuntimeError("Cluster not created yet")
+        if check_router is None:
+            check_router = self.mysql_router
 
         errors: list[str] = []
 
@@ -326,6 +425,21 @@ class GroupReplication:
             if len(secondaries) != self.num_nodes - 1:
                 errors.append(
                     f"Expected {self.num_nodes - 1} SECONDARY, got {len(secondaries)}: {members}"
+                )
+
+        if check_router:
+            self.log("verify router routes read/write traffic to the primary")
+            result = self.docker.exec_mysql(
+                self.active_nodes[0],
+                "SELECT @@hostname;",
+                host=self.router_name,
+                port=self.router_rw_port,
+                check=False,
+            )
+            routed = result.stdout.strip()
+            if not result.ok or routed != self.get_primary():
+                errors.append(
+                    f"Router RW endpoint routes to {routed!r}, expected primary {self.get_primary()!r}"
                 )
 
         if errors:
@@ -396,6 +510,10 @@ class GroupReplication:
     def destroy(self, remove_volumes: bool = False) -> None:
         """Remove all containers, optionally their data volumes, and the networks, then reset state."""
         self.log("destroy cluster")
+        if self._router_started or (self.mysql_router and self.docker.container_exists(self.router_name)):
+            self.log(f"remove router {self.router_name}")
+            self.docker.destroy(self.router_name)
+            self._router_started = False
         for name in reversed(self.containers):
             self.docker.destroy(name)
         if remove_volumes:

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -327,10 +327,12 @@ class GroupReplication:
         self.num_nodes = len(self.containers)
         self.log("persist GR settings (start_on_boot, group_seeds) on each node")
         self._persist_gr_settings(self.containers)
+        # Let the membership settle before touching the proxy (mirrors scale_up), so proxy
+        # pinning/polling doesn't run against the transient state right after removeInstance.
+        self.wait_all_online()
         if self.proxy:
             self._refresh_proxy()
             self.wait_proxy_ready()
-        self.wait_all_online()
         return to_remove
 
     def rw_endpoint(self) -> tuple[str, int]:

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -72,6 +72,7 @@ class GroupReplication:
         self.mysql_extra_args = list(mysql_extra_args or [])
         self.containers: list[str] = []
         self.active_nodes: list[str] = []
+        self.node_index: dict[str, int] = {}
         self.networks: list[str] = []
 
     def log(self, msg: str) -> None:
@@ -93,8 +94,8 @@ class GroupReplication:
         return f"{name}:{self.gr_port}"
 
     def _group_seeds(self) -> str:
-        """Build the comma-separated group_replication_group_seeds list for all nodes."""
-        return ",".join(self._gr_address(self._node_name(i)) for i in range(1, self.num_nodes + 1))
+        """Build the comma-separated group_replication_group_seeds list for all current nodes."""
+        return ",".join(self._gr_address(name) for name in self.containers)
 
     def _node_name(self, index: int) -> str:
         """Build the container/host name for the node at the given 1-based index."""
@@ -205,6 +206,98 @@ class GroupReplication:
         if name not in self.active_nodes:
             self.active_nodes.append(name)
         self.wait_all_online(timeout=timeout)
+
+    def _persist_gr_settings(self, nodes: list[str]) -> None:
+        """Persist start_on_boot and the current group_seeds list on each given node."""
+        start_on_boot = "ON" if self.start_on_boot else "OFF"
+        seeds = self._group_seeds()
+        for name in nodes:
+            self.docker.exec_mysql(
+                name,
+                f"SET PERSIST group_replication_start_on_boot={start_on_boot};"
+                f"SET PERSIST group_replication_group_seeds='{seeds}';",
+            )
+
+    def scale_up(self, count: int = 1) -> list[str]:
+        """Grow the cluster by adding count new instances, then wait for everything ONLINE.
+
+        Mirrors create()'s add path: start a fresh mysqld container, addInstance it via
+        mysqlsh (clone recovery), persist the updated seed list on all nodes, and reconcile
+        the proxy. Returns the names of the added nodes.
+        """
+        if not self.containers:
+            raise RuntimeError("Cluster not created yet")
+        if count < 1:
+            raise ValueError("count must be >= 1")
+        primary = self.primary()
+        added: list[str] = []
+        next_index = max(self.node_index.values())
+        for _ in range(count):
+            next_index += 1
+            node = self._start_mysqld_node(next_index)
+            self._wait_ready(node)
+            self.log(f"add {node} to cluster (clone)")
+            add_script = (
+                f"var c = dba.getCluster('{self.cluster_name}');"
+                f"c.addInstance('root:{self.root_password}@{node}:3306', {{"
+                f"recoveryMethod:'clone',"
+                f"localAddress:'{self._gr_address(node)}'"
+                "});"
+            )
+            self.docker.exec_mysqlsh(primary, add_script)
+            self.active_nodes.append(node)
+            added.append(node)
+
+        self.num_nodes = len(self.containers)
+        self.log("persist GR settings (start_on_boot, group_seeds) on each node")
+        self._persist_gr_settings(self.containers)
+        self.wait_all_online()
+        if self.proxy:
+            self._refresh_proxy()
+            self.wait_proxy_ready()
+        return added
+
+    def scale_down(self, count: int = 1) -> list[str]:
+        """Shrink the cluster by removing count secondaries, then wait for everything ONLINE.
+
+        Never removes the current primary. Removed nodes are taken from the most recently
+        added secondaries, removed from the InnoDB Cluster via mysqlsh, then their container
+        and data volume are destroyed. The seed list is re-persisted and the proxy reconciled.
+        Returns the names of the removed nodes.
+        """
+        if not self.containers:
+            raise RuntimeError("Cluster not created yet")
+        if count < 1:
+            raise ValueError("count must be >= 1")
+        primary = self.get_primary()
+        removable = [n for n in self.active_nodes if n != primary]
+        if count > len(removable):
+            raise ValueError(
+                f"Cannot remove {count} nodes: only {len(removable)} removable secondaries"
+            )
+        # Remove most-recently-added secondaries first.
+        to_remove = list(reversed(removable))[:count]
+        for node in to_remove:
+            self.log(f"remove {node} from cluster")
+            remove_script = (
+                f"var c = dba.getCluster('{self.cluster_name}');"
+                f"c.removeInstance('root:{self.root_password}@{node}:3306');"
+            )
+            self.docker.exec_mysqlsh(primary, remove_script)
+            self.docker.destroy(node)
+            self.docker.volume_remove(self._volume_name(self.node_index[node]))
+            self.containers.remove(node)
+            self.active_nodes.remove(node)
+            del self.node_index[node]
+
+        self.num_nodes = len(self.containers)
+        self.log("persist GR settings (start_on_boot, group_seeds) on each node")
+        self._persist_gr_settings(self.containers)
+        if self.proxy:
+            self._refresh_proxy()
+            self.wait_proxy_ready()
+        self.wait_all_online()
+        return to_remove
 
     def rw_endpoint(self) -> tuple[str, int]:
         """Return the (host, port) for read/write traffic: the proxy when enabled, else the live primary."""
@@ -365,6 +458,18 @@ class GroupReplication:
         elif self.proxy == "haproxy":
             self._start_haproxy()
 
+    def _refresh_proxy(self) -> None:
+        """Reconcile the proxy with the current membership after a scale operation.
+
+        MySQL Router auto-discovers members from the cluster metadata, so it needs nothing.
+        HAProxy's backend server list is baked into the config at start time (see
+        _haproxy_config), so the container is recreated to pick up the new node set.
+        """
+        if self.proxy == "haproxy":
+            self.log(f"refresh HAProxy {self.haproxy_name} for new membership")
+            self.docker.destroy(self.haproxy_name)
+            self._start_haproxy()
+
     def wait_proxy_ready(self, timeout: int = 120) -> None:
         """Wait until the proxy accepts connections and routes the read/write endpoint to the current primary.
 
@@ -399,6 +504,29 @@ class GroupReplication:
             f"{self.proxy} {self.proxy_name} not ready / not routing to primary in {timeout}s (last: {last!r})"
         )
 
+    def _start_mysqld_node(self, index: int) -> str:
+        """Create and start a single mysqld container for the node at the given index.
+
+        Records the node in self.containers and self.node_index and returns its name.
+        Does not add it to the InnoDB Cluster (the caller bootstraps or addInstance).
+        """
+        name = self._node_name(index)
+        self.log(f"start node {name} (server-id={index}, {self.base_host_port + index}->3306)")
+        self.docker.create(
+            image=self.image,
+            name=name,
+            hostname=name,
+            environment={"MYSQL_ROOT_PASSWORD": self.root_password},
+            volumes=[f"{self._volume_name(index)}:/var/lib/mysql"],
+            networks=[self.network],
+            ports=[f"{self.base_host_port + index}:3306"],
+            command=self._mysqld_args(server_id=index, hostname=name),
+            restart="always",
+        )
+        self.containers.append(name)
+        self.node_index[name] = index
+        return name
+
     def create(self) -> None:
         """Create the network and nodes, bootstrap the cluster, add instances, and persist GR settings."""
         self.log(f"create network {self.network}")
@@ -406,20 +534,7 @@ class GroupReplication:
         self.networks.append(self.network)
 
         for i in range(1, self.num_nodes + 1):
-            name = self._node_name(i)
-            self.log(f"start node {name} (server-id={i}, {self.base_host_port + i}->3306)")
-            self.docker.create(
-                image=self.image,
-                name=name,
-                hostname=name,
-                environment={"MYSQL_ROOT_PASSWORD": self.root_password},
-                volumes=[f"{self._volume_name(i)}:/var/lib/mysql"],
-                networks=[self.network],
-                ports=[f"{self.base_host_port + i}:3306"],
-                command=self._mysqld_args(server_id=i, hostname=name),
-                restart="always",
-            )
-            self.containers.append(name)
+            self._start_mysqld_node(i)
 
         self.active_nodes = list(self.containers)
 
@@ -461,15 +576,8 @@ class GroupReplication:
             )
         self.log("cluster is ONLINE")
 
-        start_on_boot = "ON" if self.start_on_boot else "OFF"
-        seeds = self._group_seeds()
         self.log("persist GR settings (start_on_boot, group_seeds) on each node")
-        for name in self.containers:
-            self.docker.exec_mysql(
-                name,
-                f"SET PERSIST group_replication_start_on_boot={start_on_boot};"
-                f"SET PERSIST group_replication_group_seeds='{seeds}';",
-            )
+        self._persist_gr_settings(self.containers)
 
         if self.proxy:
             self._start_proxy()
@@ -657,13 +765,15 @@ class GroupReplication:
             self.log(f"remove {self.proxy} {self.proxy_name}")
             self.docker.destroy(self.proxy_name)
             self._proxy_started = False
+        volumes = [self._volume_name(self.node_index[name]) for name in self.containers]
         for name in reversed(self.containers):
             self.docker.destroy(name)
         if remove_volumes:
-            for i in range(1, self.num_nodes + 1):
-                self.docker.volume_remove(self._volume_name(i))
+            for volume in volumes:
+                self.docker.volume_remove(volume)
         for net in self.networks:
             self.docker.network_remove(net)
         self.containers.clear()
         self.active_nodes.clear()
+        self.node_index.clear()
         self.networks.clear()

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -422,11 +422,11 @@ class GroupReplication:
     def _haproxy_config(self) -> str:
         """Build the haproxy.cfg: write frontend (:3307) to the primary, read frontend (:3308) round-robin.
 
-        HAProxy is not SQL-aware and cannot tell which member is the primary, so both backends use the
-        built-in mysql-check only for liveness (no forking external-check, which is pathologically slow
-        under the amd64-on-arm64 emulation this operator image runs in). The write backend lists every
-        node but the framework keeps only the current primary in the ready state via the runtime API
-        (see _haproxy_set_write_primary) — the same external-management model the Percona operator uses.
+        HAProxy is not SQL-aware and cannot tell which member is the primary, so health checks are
+        only a plain TCP-connect liveness probe (enabled cluster-wide via `default-server check`).
+        The write backend lists every node but the framework keeps only the current primary in the
+        ready state via the runtime API (see _haproxy_set_write_primary) — the same external-management
+        model the Percona operator uses.
         """
         servers = "\n".join(f"  server {n} {n}:3306" for n in self.containers)
         return (
@@ -447,12 +447,10 @@ class GroupReplication:
             "\n"
             "backend be_write\n"
             "  balance first\n"
-            "  option mysql-check\n"
             f"{servers}\n"
             "\n"
             "backend be_read\n"
             "  balance roundrobin\n"
-            "  option mysql-check\n"
             f"{servers}\n"
             "\n"
             "frontend fe_write\n"

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shlex
 import time
 
 from docker_helper import DockerHelper
@@ -358,8 +359,12 @@ class GroupReplication:
         """
         seed = self.active_nodes[0]
         self.log(f"start MySQL Router {self.router_name} (bootstrap from {seed})")
+        # The command runs via bash -c (it chains bootstrap && exec), so shell-quote the
+        # connection URI: a root_password with spaces/$/quotes/etc. would otherwise break
+        # the command or be shell-injected.
+        bootstrap_uri = shlex.quote(f"root:{self.root_password}@{seed}:3306")
         bootstrap = (
-            f"mysqlrouter --bootstrap root:{self.root_password}@{seed}:3306 "
+            f"mysqlrouter --bootstrap {bootstrap_uri} "
             "--directory /tmp/mysqlrouter "
             "--conf-set-option=DEFAULT.unknown_config_option=warning "
             "--conf-bind-address=0.0.0.0 --force "

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -28,10 +28,9 @@ class GroupReplication:
         router_rw_port: int = 6446,
         router_ro_port: int = 6447,
         haproxy: bool = False,
-        haproxy_image: str = "perconalab/percona-server-mysql-operator:main-haproxy",
+        haproxy_image: str = "percona/haproxy:2",
         haproxy_write_port: int = 3307,
         haproxy_read_port: int = 3308,
-        haproxy_platform: str | None = "linux/amd64",
         mysql_extra_args: list[str] | None = None,
         verbose: bool | None = None,
     ):
@@ -65,7 +64,6 @@ class GroupReplication:
         self.haproxy_name = f"{node_prefix}haproxy"
         self.haproxy_write_port = haproxy_write_port
         self.haproxy_read_port = haproxy_read_port
-        self.haproxy_platform = haproxy_platform
         # The active proxy in front of the cluster, if any.
         self.proxy = "router" if mysql_router else "haproxy" if haproxy else None
         self._proxy_started = False
@@ -452,7 +450,6 @@ class GroupReplication:
             entrypoint="bash",
             command=["-c", command],
             restart="on-failure",
-            platform=self.haproxy_platform,
         )
 
     def _start_proxy(self) -> None:

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -572,6 +572,8 @@ class GroupReplication:
             f"multiPrimary:{'false' if self.single_primary else 'true'}"
         )
         bootstrap_script = (
+            f"var c = dba.createCluster('{self.cluster_name}', {{{bootstrap_opts}}});"
+        )
         self.log(f"bootstrap cluster on {primary}")
         self.docker.exec_mysqlsh(primary, bootstrap_script, password=self.root_password)
         for i in range(2, self.num_nodes + 1):

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -242,6 +242,26 @@ class GroupReplication:
             time.sleep(2)
         raise RuntimeError(f"Not all members ONLINE within {timeout}s (last: {last})")
 
+    def wait_online_count(self, expected: int, timeout: int = 120) -> dict[str, tuple[str, str]]:
+        """Wait until exactly `expected` group members report ONLINE, returning their state map.
+
+        Used after intentionally stopping a node: failure detection and expulsion take a
+        few seconds, so the group needs a moment to settle to the smaller size before its
+        membership is inspected. Polls a surviving node; raises on timeout.
+        """
+        if not self.active_nodes:
+            raise RuntimeError("No active nodes")
+        self.log(f"wait for exactly {expected} members ONLINE")
+        deadline = time.time() + timeout
+        last: dict[str, tuple[str, str]] = {}
+        while time.time() < deadline:
+            states = self.member_states(self.active_nodes[0])
+            last = states
+            if sum(1 for state, _ in states.values() if state == "ONLINE") == expected:
+                return states
+            time.sleep(2)
+        raise RuntimeError(f"Expected {expected} ONLINE members within {timeout}s (last: {last})")
+
     def rejoin_node(self, name: str, timeout: int = 180) -> None:
         """Restart a stopped node and wait for it to auto-rejoin and all members to be ONLINE."""
         self.log(f"start node {name} (auto-rejoin)")

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -427,13 +427,15 @@ class GroupReplication:
         Uses HAProxy's runtime API over the stats socket, so writes only reach the primary even though
         mysql-check alone cannot distinguish it. Errors are ignored (e.g. before the socket is up).
         """
-        cmds = "; ".join(
-            f"set server be_write/{n} state {'ready' if n == primary else 'maint'}"
+        # HAProxy's runtime API is line-oriented: one command per line, each terminated
+        # by a newline. Joining with ';' would be sent as a single command and ignored.
+        cmds = "".join(
+            f"set server be_write/{n} state {'ready' if n == primary else 'maint'}\n"
             for n in self.containers
         )
         self.docker.exec_command(
             self.haproxy_name,
-            f"echo '{cmds}' | socat - UNIX-CONNECT:/tmp/haproxy.sock",
+            f"printf '%s' '{cmds}' | socat - UNIX-CONNECT:/tmp/haproxy.sock",
             check=False,
         )
 

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -636,16 +636,12 @@ class GroupReplication:
                 bootstrap_node, self._add_instance_script(node), password=self.root_password
             )
 
-        status = self.docker.exec_mysqlsh(
-            bootstrap_node,
-            f"var c = dba.getCluster({self._js_str(self.cluster_name)}); "
-            "print(JSON.stringify(c.status()));",
-            password=self.root_password,
-        )
-        if '"status": "ONLINE"' not in status.stdout and '"status":"ONLINE"' not in status.stdout:
-            raise RuntimeError(
-                f"Cluster did not reach ONLINE state. mysqlsh output:\n{status.stdout}\n{status.stderr}"
-            )
+        # Wait on the actual GR member states rather than string-matching c.status()
+        # output: that JSON has a per-instance "status": "ONLINE" for every member, so a
+        # substring check passes as soon as the bootstrap node is ONLINE — before clone
+        # recovery of the freshly added members has finished. wait_all_online() instead
+        # polls replication_group_members until all num_nodes members report ONLINE.
+        self.wait_all_online()
         self.log("cluster is ONLINE")
 
         self.log("persist GR settings (start_on_boot, group_seeds) on each node")

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -146,11 +146,11 @@ class GroupReplication:
         deadline = time.time() + timeout
         last = ""
         while time.time() < deadline:
-            node = self.active_nodes[0]
             result = self.docker.exec_mysql(
                 node,
                 "SELECT MEMBER_HOST FROM performance_schema.replication_group_members "
                 "WHERE MEMBER_ROLE='PRIMARY' AND MEMBER_STATE='ONLINE';",
+                password=self.root_password,
                 check=False,
             )
             host = result.stdout.strip()
@@ -572,11 +572,8 @@ class GroupReplication:
             f"multiPrimary:{'false' if self.single_primary else 'true'}"
         )
         bootstrap_script = (
-            f"var c = dba.createCluster('{self.cluster_name}', {{{bootstrap_opts}}});"
-        )
         self.log(f"bootstrap cluster on {primary}")
-        self.docker.exec_mysqlsh(primary, bootstrap_script)
-
+        self.docker.exec_mysqlsh(primary, bootstrap_script, password=self.root_password)
         for i in range(2, self.num_nodes + 1):
             node = self._node_name(i)
             self.log(f"add {node} to cluster (clone)")

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -146,6 +146,7 @@ class GroupReplication:
         deadline = time.time() + timeout
         last = ""
         while time.time() < deadline:
+            node = self.active_nodes[0]
             result = self.docker.exec_mysql(
                 node,
                 "SELECT MEMBER_HOST FROM performance_schema.replication_group_members "

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -174,6 +174,7 @@ class GroupReplication:
             node,
             "SELECT MEMBER_HOST, MEMBER_STATE "
             "FROM performance_schema.replication_group_members;",
+            password=self.root_password,
             check=False,
         )
         states: dict[str, str] = {}
@@ -215,6 +216,7 @@ class GroupReplication:
                 name,
                 f"SET PERSIST group_replication_start_on_boot={start_on_boot};"
                 f"SET PERSIST group_replication_group_seeds='{seeds}';",
+                password=self.root_password,
             )
 
     def scale_up(self, count: int = 1) -> list[str]:
@@ -243,7 +245,7 @@ class GroupReplication:
                 f"localAddress:'{self._gr_address(node)}'"
                 "});"
             )
-            self.docker.exec_mysqlsh(primary, add_script)
+            self.docker.exec_mysqlsh(primary, add_script, password=self.root_password)
             self.active_nodes.append(node)
             added.append(node)
 
@@ -282,7 +284,7 @@ class GroupReplication:
                 f"var c = dba.getCluster('{self.cluster_name}');"
                 f"c.removeInstance('root:{self.root_password}@{node}:3306');"
             )
-            self.docker.exec_mysqlsh(primary, remove_script)
+            self.docker.exec_mysqlsh(primary, remove_script, password=self.root_password)
             self.docker.destroy(node)
             self.docker.volume_remove(self._volume_name(self.node_index[node]))
             self.containers.remove(node)
@@ -327,12 +329,19 @@ class GroupReplication:
             return self.docker.exec_mysql(
                 self.active_nodes[0],
                 sql,
+                password=self.root_password,
                 database=database,
                 host=host,
                 port=port,
                 check=check,
             )
-        return self.docker.exec_mysql(self.get_primary(), sql, database=database, check=check)
+        return self.docker.exec_mysql(
+            self.get_primary(),
+            sql,
+            password=self.root_password,
+            database=database,
+            check=check,
+        )
 
     def _start_router(self) -> None:
         """Start a MySQL Router container, bootstrapping it against the live InnoDB Cluster.
@@ -492,6 +501,7 @@ class GroupReplication:
             result = self.docker.exec_mysql(
                 self.active_nodes[0],
                 "SELECT @@hostname;",
+                password=self.root_password,
                 host=host,
                 port=port,
                 check=False,
@@ -587,11 +597,12 @@ class GroupReplication:
                 f"localAddress:'{self._gr_address(node)}'"
                 "});"
             )
-            self.docker.exec_mysqlsh(primary, add_script)
+            self.docker.exec_mysqlsh(primary, add_script, password=self.root_password)
 
         status = self.docker.exec_mysqlsh(
             primary,
             f"var c = dba.getCluster('{self.cluster_name}'); print(JSON.stringify(c.status()));",
+            password=self.root_password,
         )
         if '"status": "ONLINE"' not in status.stdout and '"status":"ONLINE"' not in status.stdout:
             raise RuntimeError(
@@ -613,6 +624,7 @@ class GroupReplication:
         result = self.docker.exec_mysql(
             name,
             f"SHOW GLOBAL VARIABLES WHERE Variable_name IN ({in_clause});",
+            password=self.root_password,
         )
         actual: dict[str, str] = {}
         for line in result.stdout.strip().splitlines():
@@ -665,6 +677,7 @@ class GroupReplication:
             primary,
             "SELECT MEMBER_HOST, MEMBER_PORT, MEMBER_STATE, MEMBER_ROLE "
             "FROM performance_schema.replication_group_members;",
+            password=self.root_password,
         )
         members: list[tuple[str, str, str, str]] = []
         for line in result.stdout.strip().splitlines():
@@ -706,6 +719,7 @@ class GroupReplication:
             result = self.docker.exec_mysql(
                 self.active_nodes[0],
                 "SELECT @@hostname;",
+                password=self.root_password,
                 host=host,
                 port=port,
                 check=False,
@@ -726,13 +740,14 @@ class GroupReplication:
             "SELECT TABLE_NAME FROM information_schema.TABLES "
             f"WHERE TABLE_SCHEMA='{database}' AND TABLE_TYPE='BASE TABLE' "
             "ORDER BY TABLE_NAME;",
+            password=self.root_password,
         )
         return [line.strip() for line in result.stdout.strip().splitlines() if line.strip()]
 
     def _table_checksum(self, node: str, database: str, table: str) -> str:
         """Return the CHECKSUM TABLE value for a single table on the given node."""
         result = self.docker.exec_mysql(
-            node, f"CHECKSUM TABLE `{database}`.`{table}`;"
+            node, f"CHECKSUM TABLE `{database}`.`{table}`;", password=self.root_password
         )
         # Output is "<database>.<table>\t<checksum>" (or NULL if the table is missing).
         parts = result.stdout.strip().split("\t")

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -366,7 +366,7 @@ class GroupReplication:
             image=self.router_image,
             name=self.router_name,
             hostname=self.router_name,
-            networks=[self.network],
+            network=self.network,
             ports=[
                 f"{self.base_host_port + 90}:{self.router_rw_port}",
                 f"{self.base_host_port + 91}:{self.router_ro_port}",
@@ -456,7 +456,7 @@ class GroupReplication:
             name=self.haproxy_name,
             hostname=self.haproxy_name,
             environment={"HAPROXY_CFG": self._haproxy_config()},
-            networks=[self.network],
+            network=self.network,
             ports=[
                 f"{self.base_host_port + 92}:{self.haproxy_write_port}",
                 f"{self.base_host_port + 93}:{self.haproxy_read_port}",
@@ -534,7 +534,7 @@ class GroupReplication:
             hostname=name,
             environment={"MYSQL_ROOT_PASSWORD": self.root_password},
             volumes=[f"{self._volume_name(index)}:/var/lib/mysql"],
-            networks=[self.network],
+            network=self.network,
             ports=[f"{self.base_host_port + index}:3306"],
             command=self._mysqld_args(server_id=index, hostname=name),
             restart="always",

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -192,6 +192,7 @@ class GroupReplication:
                 "WHERE MEMBER_ROLE='PRIMARY' AND MEMBER_STATE='ONLINE';",
                 password=self.root_password,
                 check=False,
+                timeout=15,
             )
             host = result.stdout.strip()
             if result.ok and host and "\n" not in host:
@@ -215,6 +216,7 @@ class GroupReplication:
             "FROM performance_schema.replication_group_members;",
             password=self.root_password,
             check=False,
+            timeout=15,
         )
         states: dict[str, str] = {}
         if result.ok:

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import shlex
@@ -91,6 +92,27 @@ class GroupReplication:
     def _gr_address(self, name: str) -> str:
         """Build the GR communication address (host:gr_port) for a node."""
         return f"{name}:{self.gr_port}"
+
+    @staticmethod
+    def _js_str(value: str) -> str:
+        """Encode a Python string as a JavaScript string literal for mysqlsh --js scripts.
+
+        JSON encoding yields a valid JS string literal with quotes, backslashes, and
+        control/non-ASCII characters escaped, so values like cluster_name or the
+        connection URI (which contains root_password) can't break the script or inject.
+        """
+        return json.dumps(value)
+
+    def _add_instance_script(self, node: str) -> str:
+        """Build the mysqlsh AdminAPI script to add a node to the cluster (clone recovery)."""
+        uri = f"root:{self.root_password}@{node}:3306"
+        return (
+            f"var c = dba.getCluster({self._js_str(self.cluster_name)});"
+            f"c.addInstance({self._js_str(uri)}, {{"
+            f"recoveryMethod:'clone',"
+            f"localAddress:{self._js_str(self._gr_address(node))}"
+            "});"
+        )
 
     def _group_seeds(self) -> str:
         """Build the comma-separated group_replication_group_seeds list for all current nodes."""
@@ -244,14 +266,9 @@ class GroupReplication:
             node = self._start_mysqld_node(next_index)
             self._wait_ready(node)
             self.log(f"add {node} to cluster (clone)")
-            add_script = (
-                f"var c = dba.getCluster('{self.cluster_name}');"
-                f"c.addInstance('root:{self.root_password}@{node}:3306', {{"
-                f"recoveryMethod:'clone',"
-                f"localAddress:'{self._gr_address(node)}'"
-                "});"
+            self.docker.exec_mysqlsh(
+                primary, self._add_instance_script(node), password=self.root_password
             )
-            self.docker.exec_mysqlsh(primary, add_script, password=self.root_password)
             self.active_nodes.append(node)
             added.append(node)
 
@@ -286,9 +303,10 @@ class GroupReplication:
         to_remove = list(reversed(removable))[:count]
         for node in to_remove:
             self.log(f"remove {node} from cluster")
+            uri = f"root:{self.root_password}@{node}:3306"
             remove_script = (
-                f"var c = dba.getCluster('{self.cluster_name}');"
-                f"c.removeInstance('root:{self.root_password}@{node}:3306');"
+                f"var c = dba.getCluster({self._js_str(self.cluster_name)});"
+                f"c.removeInstance({self._js_str(uri)});"
             )
             self.docker.exec_mysqlsh(primary, remove_script, password=self.root_password)
             self.docker.destroy(node)
@@ -589,31 +607,27 @@ class GroupReplication:
 
         primary = self.primary()
         bootstrap_opts = (
-            f"groupName:'{self.group_name}',"
-            f"communicationStack:'{self.communication_stack}',"
-            f"localAddress:'{self._gr_address(primary)}',"
+            f"groupName:{self._js_str(self.group_name)},"
+            f"communicationStack:{self._js_str(self.communication_stack)},"
+            f"localAddress:{self._js_str(self._gr_address(primary))},"
             f"multiPrimary:{'false' if self.single_primary else 'true'}"
         )
         bootstrap_script = (
-            f"var c = dba.createCluster('{self.cluster_name}', {{{bootstrap_opts}}});"
+            f"var c = dba.createCluster({self._js_str(self.cluster_name)}, {{{bootstrap_opts}}});"
         )
         self.log(f"bootstrap cluster on {primary}")
         self.docker.exec_mysqlsh(primary, bootstrap_script, password=self.root_password)
         for i in range(2, self.num_nodes + 1):
             node = self._node_name(i)
             self.log(f"add {node} to cluster (clone)")
-            add_script = (
-                f"var c = dba.getCluster('{self.cluster_name}');"
-                f"c.addInstance('root:{self.root_password}@{node}:3306', {{"
-                f"recoveryMethod:'clone',"
-                f"localAddress:'{self._gr_address(node)}'"
-                "});"
+            self.docker.exec_mysqlsh(
+                primary, self._add_instance_script(node), password=self.root_password
             )
-            self.docker.exec_mysqlsh(primary, add_script, password=self.root_password)
 
         status = self.docker.exec_mysqlsh(
             primary,
-            f"var c = dba.getCluster('{self.cluster_name}'); print(JSON.stringify(c.status()));",
+            f"var c = dba.getCluster({self._js_str(self.cluster_name)}); "
+            "print(JSON.stringify(c.status()));",
             password=self.root_password,
         )
         if '"status": "ONLINE"' not in status.stdout and '"status":"ONLINE"' not in status.stdout:

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -637,6 +637,21 @@ class GroupReplication:
         self._wait_ready(name)
         return name
 
+    def mysqlsh_available(self) -> bool:
+        """Return True if the MySQL Shell (mysqlsh) binary ships in the server image.
+
+        Cluster bootstrap and instance-add go through mysqlsh's AdminAPI (see create()),
+        so a server build without it cannot run this suite. Probed with a throwaway
+        --rm container running `mysqlsh --version` (no node startup, no connection).
+        """
+        result = self.docker.run(
+            image=self.server_image,
+            entrypoint="mysqlsh",
+            command=["--version"],
+            check=False,
+        )
+        return result.ok
+
     def create(self) -> None:
         """Create the network and nodes, bootstrap the cluster, add instances, and persist GR settings."""
         self.log(f"create network {self.network}")

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -546,7 +546,13 @@ class GroupReplication:
             # left, so a missing primary can't push total wall time far past our timeout
             # (get_primary alone can otherwise block up to 60s, and was called twice/iter).
             remaining = max(1, int(deadline - time.time()))
-            primary = self.get_primary(timeout=remaining)
+            try:
+                primary = self.get_primary(timeout=remaining)
+            except RuntimeError as exc:
+                # No PRIMARY elected yet (e.g. mid-failover): keep polling until our own
+                # deadline rather than aborting on get_primary()'s error.
+                last = str(exc)
+                continue
             # HAProxy can't detect the primary itself; (re-)pin the write backend to the
             # current primary each iteration. Idempotent, and self-heals after failover.
             if self.proxy == "haproxy":

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -536,10 +536,15 @@ class GroupReplication:
         deadline = time.time() + timeout
         last = ""
         while time.time() < deadline:
+            # Resolve the primary once per iteration and bound get_primary() by the time
+            # left, so a missing primary can't push total wall time far past our timeout
+            # (get_primary alone can otherwise block up to 60s, and was called twice/iter).
+            remaining = max(1, int(deadline - time.time()))
+            primary = self.get_primary(timeout=remaining)
             # HAProxy can't detect the primary itself; (re-)pin the write backend to the
             # current primary each iteration. Idempotent, and self-heals after failover.
             if self.proxy == "haproxy":
-                self._haproxy_set_write_primary(self.get_primary())
+                self._haproxy_set_write_primary(primary)
             result = self.docker.exec_mysql(
                 self.active_nodes[0],
                 "SELECT @@hostname;",
@@ -550,7 +555,7 @@ class GroupReplication:
                 timeout=15,
             )
             routed = result.stdout.strip()
-            if result.ok and routed and routed == self.get_primary():
+            if result.ok and routed and routed == primary:
                 return
             last = routed or (result.stderr or "").strip()
             time.sleep(2)

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -740,45 +740,56 @@ class GroupReplication:
         # intentionally stopped during failover testing while other members are ONLINE.
         query_node = self.active_nodes[0]
         self.log("check membership via replication_group_members")
+        # check=False so a transient query failure becomes a structured verify error
+        # rather than raising and bypassing the collected errors; bounded so a hung mysql
+        # client can't stall verify().
         result = self.docker.exec_mysql(
             query_node,
             "SELECT MEMBER_HOST, MEMBER_PORT, MEMBER_STATE, MEMBER_ROLE "
             "FROM performance_schema.replication_group_members;",
             password=self.root_password,
+            check=False,
+            timeout=15,
         )
-        members: list[tuple[str, str, str, str]] = []
-        for line in result.stdout.strip().splitlines():
-            parts = line.split("\t")
-            if len(parts) >= 4:
-                members.append((parts[0], parts[1], parts[2], parts[3]))
-
-        if len(members) != self.num_nodes:
+        if not result.ok:
             errors.append(
-                f"Expected {self.num_nodes} members in replication_group_members, "
-                f"got {len(members)}: {members}"
+                f"Failed to query replication_group_members on {query_node}: "
+                f"{(result.stderr or result.stdout).strip()!r}"
             )
+        else:
+            members: list[tuple[str, str, str, str]] = []
+            for line in result.stdout.strip().splitlines():
+                parts = line.split("\t")
+                if len(parts) >= 4:
+                    members.append((parts[0], parts[1], parts[2], parts[3]))
 
-        hosts = sorted(m[0] for m in members)
-        expected_hosts = sorted(self.containers)
-        if hosts != expected_hosts:
-            errors.append(f"Member hosts mismatch: got {hosts}, expected {expected_hosts}")
-
-        bad_state = [m for m in members if m[2] != "ONLINE"]
-        if bad_state:
-            errors.append(f"Members not ONLINE: {bad_state}")
-
-        primaries = [m for m in members if m[3] == "PRIMARY"]
-        secondaries = [m for m in members if m[3] == "SECONDARY"]
-        primary_hosts = ", ".join(sorted(m[0] for m in primaries)) or "none"
-        secondary_hosts = ", ".join(sorted(m[0] for m in secondaries)) or "none"
-        self.log(f"primary: {primary_hosts}; secondaries: {secondary_hosts}")
-        if self.single_primary:
-            if len(primaries) != 1:
-                errors.append(f"Expected exactly 1 PRIMARY, got {len(primaries)}: {members}")
-            if len(secondaries) != self.num_nodes - 1:
+            if len(members) != self.num_nodes:
                 errors.append(
-                    f"Expected {self.num_nodes - 1} SECONDARY, got {len(secondaries)}: {members}"
+                    f"Expected {self.num_nodes} members in replication_group_members, "
+                    f"got {len(members)}: {members}"
                 )
+
+            hosts = sorted(m[0] for m in members)
+            expected_hosts = sorted(self.containers)
+            if hosts != expected_hosts:
+                errors.append(f"Member hosts mismatch: got {hosts}, expected {expected_hosts}")
+
+            bad_state = [m for m in members if m[2] != "ONLINE"]
+            if bad_state:
+                errors.append(f"Members not ONLINE: {bad_state}")
+
+            primaries = [m for m in members if m[3] == "PRIMARY"]
+            secondaries = [m for m in members if m[3] == "SECONDARY"]
+            primary_hosts = ", ".join(sorted(m[0] for m in primaries)) or "none"
+            secondary_hosts = ", ".join(sorted(m[0] for m in secondaries)) or "none"
+            self.log(f"primary: {primary_hosts}; secondaries: {secondary_hosts}")
+            if self.single_primary:
+                if len(primaries) != 1:
+                    errors.append(f"Expected exactly 1 PRIMARY, got {len(primaries)}: {members}")
+                if len(secondaries) != self.num_nodes - 1:
+                    errors.append(
+                        f"Expected {self.num_nodes - 1} SECONDARY, got {len(secondaries)}: {members}"
+                    )
 
         if check_proxy and self.proxy:
             self.log(f"verify {self.proxy} routes read/write traffic to the primary")

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -119,15 +119,18 @@ class GroupReplication:
         return args
 
     def _wait_ready(self, name: str, timeout: int = 180) -> None:
-        """Wait until a node accepts MySQL connections (responds to ping), or time out."""
+        """Wait until a node accepts MySQL connections (runs a trivial query), or time out."""
         self.log(f"wait for {name} to accept connections")
         deadline = time.time() + timeout
         last_err = ""
         while time.time() < deadline:
-            result = self.docker.exec_command(
-                name, f"mysqladmin -uroot -p{self.root_password} ping --silent"
+            # Probe via exec_mysql (no shell) rather than mysqladmin via sh -c, so a
+            # root_password with shell metacharacters/spaces can't break the loop or be
+            # mangled by shell parsing.
+            result = self.docker.exec_mysql(
+                name, "SELECT 1;", password=self.root_password, check=False, timeout=15
             )
-            if result.ok and "mysqld is alive" in result.stdout:
+            if result.ok:
                 return
             last_err = (result.stderr or result.stdout).strip()
             time.sleep(2)

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shlex
 import time
+from urllib.parse import quote
 
 from docker_helper import DockerHelper
 
@@ -103,12 +104,20 @@ class GroupReplication:
         """
         return json.dumps(value)
 
+    def _instance_uri(self, node: str) -> str:
+        """Build the AdminAPI connection URI for a node, percent-encoding the credentials.
+
+        Even though the URI is embedded as an escaped JS string, mysqlsh then parses it
+        as a connection string, so a password with URI-reserved characters (@ : / # ?)
+        must be encoded or AdminAPI misparses it.
+        """
+        return f"root:{quote(self.root_password, safe='')}@{node}:3306"
+
     def _add_instance_script(self, node: str) -> str:
         """Build the mysqlsh AdminAPI script to add a node to the cluster (clone recovery)."""
-        uri = f"root:{self.root_password}@{node}:3306"
         return (
             f"var c = dba.getCluster({self._js_str(self.cluster_name)});"
-            f"c.addInstance({self._js_str(uri)}, {{"
+            f"c.addInstance({self._js_str(self._instance_uri(node))}, {{"
             f"recoveryMethod:'clone',"
             f"localAddress:{self._js_str(self._gr_address(node))}"
             "});"
@@ -303,10 +312,9 @@ class GroupReplication:
         to_remove = list(reversed(removable))[:count]
         for node in to_remove:
             self.log(f"remove {node} from cluster")
-            uri = f"root:{self.root_password}@{node}:3306"
             remove_script = (
                 f"var c = dba.getCluster({self._js_str(self.cluster_name)});"
-                f"c.removeInstance({self._js_str(uri)});"
+                f"c.removeInstance({self._js_str(self._instance_uri(node))});"
             )
             self.docker.exec_mysqlsh(primary, remove_script, password=self.root_password)
             self.docker.destroy(node)
@@ -377,10 +385,10 @@ class GroupReplication:
         """
         seed = self.active_nodes[0]
         self.log(f"start MySQL Router {self.router_name} (bootstrap from {seed})")
-        # The command runs via bash -c (it chains bootstrap && exec), so shell-quote the
-        # connection URI: a root_password with spaces/$/quotes/etc. would otherwise break
-        # the command or be shell-injected.
-        bootstrap_uri = shlex.quote(f"root:{self.root_password}@{seed}:3306")
+        # _instance_uri percent-encodes the credentials so mysqlrouter parses the URI
+        # correctly; shlex.quote then protects the surrounding bash -c command (it chains
+        # bootstrap && exec) from a password with spaces/$/quotes/etc.
+        bootstrap_uri = shlex.quote(self._instance_uri(seed))
         bootstrap = (
             f"mysqlrouter --bootstrap {bootstrap_uri} "
             "--directory /tmp/mysqlrouter "

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -41,6 +41,11 @@ class GroupReplication:
             raise ValueError("num_nodes must be >= 1")
         if mysql_router and haproxy:
             raise ValueError("mysql_router and haproxy are mutually exclusive")
+        if not single_primary:
+            # Multi-primary mode is not currently supported by this framework: several
+            # helpers (notably get_primary(), the proxy write-endpoint routing, and the
+            # single-PRIMARY assertions in verify()) assume exactly one ONLINE primary.
+            raise ValueError("multi-primary mode (single_primary=False) is not supported")
         if verbose is None:
             verbose = os.environ.get("GR_VERBOSE", "").lower() in ("1", "true", "yes", "on")
         self.verbose = verbose

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -181,13 +181,16 @@ class GroupReplication:
         last = ""
         while time.time() < deadline:
             node = self.active_nodes[0]
+            # Cap the per-query timeout at the time left so a single probe can't overrun
+            # the caller-provided deadline (callers may pass less than the usual 15s).
+            query_timeout = min(15, max(1, int(deadline - time.time())))
             result = self.docker.exec_mysql(
                 node,
                 "SELECT MEMBER_HOST FROM performance_schema.replication_group_members "
                 "WHERE MEMBER_ROLE='PRIMARY' AND MEMBER_STATE='ONLINE';",
                 password=self.root_password,
                 check=False,
-                timeout=15,
+                timeout=query_timeout,
             )
             host = result.stdout.strip()
             if result.ok and host and "\n" not in host:
@@ -560,6 +563,9 @@ class GroupReplication:
             # current primary each iteration. Idempotent, and self-heals after failover.
             if self.proxy == "haproxy":
                 self._haproxy_set_write_primary(primary)
+            # Cap the probe timeout at the time left (get_primary above may have consumed
+            # part of the budget) so a stuck probe can't overrun our own timeout.
+            probe_timeout = min(15, max(1, int(deadline - time.time())))
             result = self.docker.exec_mysql(
                 self.active_nodes[0],
                 "SELECT @@hostname;",
@@ -567,7 +573,7 @@ class GroupReplication:
                 host=host,
                 port=port,
                 check=False,
-                timeout=15,
+                timeout=probe_timeout,
             )
             routed = result.stdout.strip()
             if result.ok and routed and routed == primary:

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -209,22 +209,22 @@ class GroupReplication:
         if name in self.active_nodes:
             self.active_nodes.remove(name)
 
-    def _member_states(self, node: str) -> dict[str, str]:
-        """Read the host->state map of all group members as seen from the given node."""
+    def member_states(self, node: str) -> dict[str, tuple[str, str]]:
+        """Read the host->(state, role) map of all group members as seen from the given node."""
         result = self.docker.exec_mysql(
             node,
-            "SELECT MEMBER_HOST, MEMBER_STATE "
+            "SELECT MEMBER_HOST, MEMBER_STATE, MEMBER_ROLE "
             "FROM performance_schema.replication_group_members;",
             password=self.root_password,
             check=False,
             timeout=15,
         )
-        states: dict[str, str] = {}
+        states: dict[str, tuple[str, str]] = {}
         if result.ok:
             for line in result.stdout.strip().splitlines():
                 parts = line.split("\t")
-                if len(parts) >= 2:
-                    states[parts[0]] = parts[1]
+                if len(parts) >= 3:
+                    states[parts[0]] = (parts[1], parts[2])
         return states
 
     def wait_all_online(self, timeout: int = 180) -> None:
@@ -233,11 +233,11 @@ class GroupReplication:
             raise RuntimeError("No active nodes")
         self.log("wait for all members ONLINE")
         deadline = time.time() + timeout
-        last: dict[str, str] = {}
+        last: dict[str, tuple[str, str]] = {}
         while time.time() < deadline:
-            states = self._member_states(self.active_nodes[0])
+            states = self.member_states(self.active_nodes[0])
             last = states
-            if len(states) == self.num_nodes and all(s == "ONLINE" for s in states.values()):
+            if len(states) == self.num_nodes and all(s == "ONLINE" for s, _ in states.values()):
                 return
             time.sleep(2)
         raise RuntimeError(f"Not all members ONLINE within {timeout}s (last: {last})")

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -27,11 +27,18 @@ class GroupReplication:
         router_image: str = "percona/percona-mysql-router:8.4",
         router_rw_port: int = 6446,
         router_ro_port: int = 6447,
+        haproxy: bool = False,
+        haproxy_image: str = "perconalab/percona-server-mysql-operator:main-haproxy",
+        haproxy_write_port: int = 3307,
+        haproxy_read_port: int = 3308,
+        haproxy_platform: str | None = "linux/amd64",
         mysql_extra_args: list[str] | None = None,
         verbose: bool | None = None,
     ):
         if num_nodes < 1:
             raise ValueError("num_nodes must be >= 1")
+        if mysql_router and haproxy:
+            raise ValueError("mysql_router and haproxy are mutually exclusive")
         if verbose is None:
             verbose = os.environ.get("GR_VERBOSE", "").lower() in ("1", "true", "yes", "on")
         self.verbose = verbose
@@ -53,7 +60,15 @@ class GroupReplication:
         self.router_name = f"{node_prefix}router"
         self.router_rw_port = router_rw_port
         self.router_ro_port = router_ro_port
-        self._router_started = False
+        self.haproxy = haproxy
+        self.haproxy_image = haproxy_image
+        self.haproxy_name = f"{node_prefix}haproxy"
+        self.haproxy_write_port = haproxy_write_port
+        self.haproxy_read_port = haproxy_read_port
+        self.haproxy_platform = haproxy_platform
+        # The active proxy in front of the cluster, if any.
+        self.proxy = "router" if mysql_router else "haproxy" if haproxy else None
+        self._proxy_started = False
         self.mysql_extra_args = list(mysql_extra_args or [])
         self.containers: list[str] = []
         self.active_nodes: list[str] = []
@@ -63,6 +78,15 @@ class GroupReplication:
         """Log a message, but only when verbose mode is enabled."""
         if self.verbose:
             _logger.info(msg)
+
+    @property
+    def proxy_name(self) -> str | None:
+        """Container name of the active proxy (router/haproxy), or None when running direct."""
+        if self.proxy == "router":
+            return self.router_name
+        if self.proxy == "haproxy":
+            return self.haproxy_name
+        return None
 
     def _gr_address(self, name: str) -> str:
         """Build the GR communication address (host:gr_port) for a node."""
@@ -183,28 +207,33 @@ class GroupReplication:
         self.wait_all_online(timeout=timeout)
 
     def rw_endpoint(self) -> tuple[str, int]:
-        """Return the (host, port) for read/write traffic: the router when enabled, else the live primary."""
-        if self.mysql_router:
+        """Return the (host, port) for read/write traffic: the proxy when enabled, else the live primary."""
+        if self.proxy == "router":
             return (self.router_name, self.router_rw_port)
+        if self.proxy == "haproxy":
+            return (self.haproxy_name, self.haproxy_write_port)
         return (self.get_primary(), 3306)
 
     def ro_endpoint(self) -> tuple[str, int]:
-        """Return the (host, port) for read-only traffic: the router when enabled, else an active secondary."""
-        if self.mysql_router:
+        """Return the (host, port) for read-only traffic: the proxy when enabled, else an active secondary."""
+        if self.proxy == "router":
             return (self.router_name, self.router_ro_port)
+        if self.proxy == "haproxy":
+            return (self.haproxy_name, self.haproxy_read_port)
         primary = self.get_primary()
         secondaries = [n for n in self.active_nodes if n != primary]
         return ((secondaries[0] if secondaries else primary), 3306)
 
     def exec_sql(self, sql: str, database: str | None = None, check: bool = True):
-        """Run application SQL through the read/write endpoint (via the router when enabled, else direct to the primary)."""
-        if self.mysql_router:
+        """Run application SQL through the read/write endpoint (via the proxy when enabled, else direct to the primary)."""
+        if self.proxy:
+            host, port = self.rw_endpoint()
             return self.docker.exec_mysql(
                 self.active_nodes[0],
                 sql,
                 database=database,
-                host=self.router_name,
-                port=self.router_rw_port,
+                host=host,
+                port=port,
                 check=check,
             )
         return self.docker.exec_mysql(self.get_primary(), sql, database=database, check=check)
@@ -240,25 +269,135 @@ class GroupReplication:
             restart="on-failure",
         )
 
-    def _wait_router_ready(self, timeout: int = 60) -> None:
-        """Wait until the router accepts connections and routes the read/write port to the current primary."""
-        self.log(f"wait for router {self.router_name} to route to the primary")
+    def _haproxy_config(self) -> str:
+        """Build the haproxy.cfg: write frontend (:3307) to the primary, read frontend (:3308) round-robin.
+
+        HAProxy is not SQL-aware and cannot tell which member is the primary, so both backends use the
+        built-in mysql-check only for liveness (no forking external-check, which is pathologically slow
+        under the amd64-on-arm64 emulation this operator image runs in). The write backend lists every
+        node but the framework keeps only the current primary in the ready state via the runtime API
+        (see _haproxy_set_write_primary) — the same external-management model the Percona operator uses.
+        """
+        servers = "\n".join(f"  server {n} {n}:3306" for n in self.containers)
+        return (
+            "global\n"
+            "  maxconn 2048\n"
+            "  log stdout format raw local0\n"
+            "  stats socket /tmp/haproxy.sock mode 660 level admin\n"
+            "\n"
+            "defaults\n"
+            "  mode tcp\n"
+            "  log global\n"
+            "  option tcplog\n"
+            "  timeout connect 5s\n"
+            "  timeout queue 10s\n"
+            "  timeout client 30m\n"
+            "  timeout server 30m\n"
+            "  default-server check inter 2s rise 1 fall 3\n"
+            "\n"
+            "backend be_write\n"
+            "  balance first\n"
+            "  option mysql-check\n"
+            f"{servers}\n"
+            "\n"
+            "backend be_read\n"
+            "  balance roundrobin\n"
+            "  option mysql-check\n"
+            f"{servers}\n"
+            "\n"
+            "frontend fe_write\n"
+            f"  bind :{self.haproxy_write_port}\n"
+            "  default_backend be_write\n"
+            "\n"
+            "frontend fe_read\n"
+            f"  bind :{self.haproxy_read_port}\n"
+            "  default_backend be_read\n"
+        )
+
+    def _haproxy_set_write_primary(self, primary: str) -> None:
+        """Pin the write backend to the given primary: mark it ready and every other node in maintenance.
+
+        Uses HAProxy's runtime API over the stats socket, so writes only reach the primary even though
+        mysql-check alone cannot distinguish it. Errors are ignored (e.g. before the socket is up).
+        """
+        cmds = "; ".join(
+            f"set server be_write/{n} state {'ready' if n == primary else 'maint'}"
+            for n in self.containers
+        )
+        self.docker.exec_command(
+            self.haproxy_name,
+            f"echo '{cmds}' | socat - UNIX-CONNECT:/tmp/haproxy.sock",
+            check=False,
+        )
+
+    def _start_haproxy(self) -> None:
+        """Start a Percona HAProxy container fronting the cluster (write :3307, read :3308).
+
+        The config is injected via an environment variable (avoids host bind mounts, unreliable under
+        podman-on-macOS) and written to /tmp before haproxy is exec'd in the foreground as the image's
+        non-root user.
+        """
+        self.log(f"start HAProxy {self.haproxy_name} (write:{self.haproxy_write_port} read:{self.haproxy_read_port})")
+        command = (
+            'printf "%s\\n" "$HAPROXY_CFG" > /tmp/haproxy.cfg && '
+            "exec haproxy -W -db -f /tmp/haproxy.cfg"
+        )
+        self.docker.create(
+            image=self.haproxy_image,
+            name=self.haproxy_name,
+            hostname=self.haproxy_name,
+            environment={"HAPROXY_CFG": self._haproxy_config()},
+            networks=[self.network],
+            ports=[
+                f"{self.base_host_port + 92}:{self.haproxy_write_port}",
+                f"{self.base_host_port + 93}:{self.haproxy_read_port}",
+            ],
+            entrypoint="bash",
+            command=["-c", command],
+            restart="on-failure",
+            platform=self.haproxy_platform,
+        )
+
+    def _start_proxy(self) -> None:
+        """Start whichever proxy (router or haproxy) is configured in front of the cluster."""
+        if self.proxy == "router":
+            self._start_router()
+        elif self.proxy == "haproxy":
+            self._start_haproxy()
+
+    def wait_proxy_ready(self, timeout: int = 120) -> None:
+        """Wait until the proxy accepts connections and routes the read/write endpoint to the current primary.
+
+        The default is generous because HAProxy's external health checks can take tens of seconds to
+        first stabilize when the operator image runs under CPU emulation.
+        """
+        if not self.proxy:
+            return
+        host, port = self.rw_endpoint()
+        self.log(f"wait for {self.proxy} {self.proxy_name} to route to the primary")
         deadline = time.time() + timeout
         last = ""
         while time.time() < deadline:
+            # HAProxy can't detect the primary itself; (re-)pin the write backend to the
+            # current primary each iteration. Idempotent, and self-heals after failover.
+            if self.proxy == "haproxy":
+                self._haproxy_set_write_primary(self.get_primary())
             result = self.docker.exec_mysql(
                 self.active_nodes[0],
                 "SELECT @@hostname;",
-                host=self.router_name,
-                port=self.router_rw_port,
+                host=host,
+                port=port,
                 check=False,
+                timeout=15,
             )
             routed = result.stdout.strip()
             if result.ok and routed and routed == self.get_primary():
                 return
             last = routed or (result.stderr or "").strip()
             time.sleep(2)
-        raise RuntimeError(f"Router {self.router_name} not ready / not routing to primary in {timeout}s (last: {last!r})")
+        raise RuntimeError(
+            f"{self.proxy} {self.proxy_name} not ready / not routing to primary in {timeout}s (last: {last!r})"
+        )
 
     def create(self) -> None:
         """Create the network and nodes, bootstrap the cluster, add instances, and persist GR settings."""
@@ -332,10 +471,10 @@ class GroupReplication:
                 f"SET PERSIST group_replication_group_seeds='{seeds}';",
             )
 
-        if self.mysql_router:
-            self._start_router()
-            self._router_started = True
-            self._wait_router_ready()
+        if self.proxy:
+            self._start_proxy()
+            self._proxy_started = True
+            self.wait_proxy_ready()
 
     def _read_variables(self, name: str, variables: list[str]) -> dict[str, str]:
         """Read the given global variables from a node as a name->value map."""
@@ -351,16 +490,16 @@ class GroupReplication:
                 actual[parts[0]] = parts[1]
         return actual
 
-    def verify(self, check_router: bool | None = None) -> None:
+    def verify(self, check_proxy: bool | None = None) -> None:
         """Assert that GR variables, membership, states, and roles match the expected configuration.
 
-        When check_router is set (defaults to whether the router is enabled), also assert that the
-        router's read/write endpoint routes to the current primary.
+        When check_proxy is set (defaults to whether a proxy is enabled), also assert that the
+        proxy's read/write endpoint routes to the current primary.
         """
         if not self.containers:
             raise RuntimeError("Cluster not created yet")
-        if check_router is None:
-            check_router = self.mysql_router
+        if check_proxy is None:
+            check_proxy = self.proxy is not None
 
         errors: list[str] = []
 
@@ -427,19 +566,20 @@ class GroupReplication:
                     f"Expected {self.num_nodes - 1} SECONDARY, got {len(secondaries)}: {members}"
                 )
 
-        if check_router:
-            self.log("verify router routes read/write traffic to the primary")
+        if check_proxy and self.proxy:
+            self.log(f"verify {self.proxy} routes read/write traffic to the primary")
+            host, port = self.rw_endpoint()
             result = self.docker.exec_mysql(
                 self.active_nodes[0],
                 "SELECT @@hostname;",
-                host=self.router_name,
-                port=self.router_rw_port,
+                host=host,
+                port=port,
                 check=False,
             )
             routed = result.stdout.strip()
             if not result.ok or routed != self.get_primary():
                 errors.append(
-                    f"Router RW endpoint routes to {routed!r}, expected primary {self.get_primary()!r}"
+                    f"{self.proxy} RW endpoint routes to {routed!r}, expected primary {self.get_primary()!r}"
                 )
 
         if errors:
@@ -510,10 +650,10 @@ class GroupReplication:
     def destroy(self, remove_volumes: bool = False) -> None:
         """Remove all containers, optionally their data volumes, and the networks, then reset state."""
         self.log("destroy cluster")
-        if self._router_started or (self.mysql_router and self.docker.container_exists(self.router_name)):
-            self.log(f"remove router {self.router_name}")
-            self.docker.destroy(self.router_name)
-            self._router_started = False
+        if self.proxy_name and (self._proxy_started or self.docker.container_exists(self.proxy_name)):
+            self.log(f"remove {self.proxy} {self.proxy_name}")
+            self.docker.destroy(self.proxy_name)
+            self._proxy_started = False
         for name in reversed(self.containers):
             self.docker.destroy(name)
         if remove_volumes:

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -597,6 +597,10 @@ class GroupReplication:
             image=self.server_image,
             name=name,
             hostname=name,
+            # Ignored for a pre-populated (restored) datadir, but lets the image's
+            # entrypoint initialize successfully if the volume is empty/partial — otherwise
+            # init fails, mysqld never starts, and _wait_ready hangs until it times out.
+            environment={"MYSQL_ROOT_PASSWORD": self.root_password},
             volumes=[f"{data_volume}:/var/lib/mysql"],
             command=self._mysqld_args(server_id=server_id, hostname=name)
             + ["--group-replication-start-on-boot=OFF"],

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -13,7 +13,7 @@ class GroupReplication:
         docker: DockerHelper,
         num_nodes: int = 3,
         network: str = "grnet",
-        server_image: str = "percona/percona-server:8.4",
+        server_image: str | None = None,
         node_prefix: str = "ps",
         root_password: str = "rootpass",
         base_host_port: int = 33060,
@@ -24,11 +24,11 @@ class GroupReplication:
         single_primary: bool = True,
         start_on_boot: bool = True,
         mysql_router: bool = False,
-        router_image: str = "percona/percona-mysql-router:8.4",
+        router_image: str | None = None,
         router_rw_port: int = 6446,
         router_ro_port: int = 6447,
         haproxy: bool = False,
-        haproxy_image: str = "percona/haproxy:2",
+        haproxy_image: str | None = None,
         haproxy_write_port: int = 3307,
         haproxy_read_port: int = 3308,
         mysql_extra_args: list[str] | None = None,
@@ -44,7 +44,7 @@ class GroupReplication:
         self.docker = docker
         self.num_nodes = num_nodes
         self.network = network
-        self.server_image = server_image
+        self.server_image = server_image or os.environ.get("SERVER_IMAGE") or "percona/percona-server:8.4"
         self.node_prefix = node_prefix
         self.root_password = root_password
         self.base_host_port = base_host_port
@@ -55,12 +55,12 @@ class GroupReplication:
         self.single_primary = single_primary
         self.start_on_boot = start_on_boot
         self.mysql_router = mysql_router
-        self.router_image = router_image
+        self.router_image = router_image or os.environ.get("ROUTER_IMAGE") or "percona/percona-mysql-router:8.4"
         self.router_name = f"{node_prefix}router"
         self.router_rw_port = router_rw_port
         self.router_ro_port = router_ro_port
         self.haproxy = haproxy
-        self.haproxy_image = haproxy_image
+        self.haproxy_image = haproxy_image or os.environ.get("HAPROXY_IMAGE") or "percona/haproxy:2"
         self.haproxy_name = f"{node_prefix}haproxy"
         self.haproxy_write_port = haproxy_write_port
         self.haproxy_read_port = haproxy_read_port

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -554,6 +554,7 @@ class GroupReplication:
                 # No PRIMARY elected yet (e.g. mid-failover): keep polling until our own
                 # deadline rather than aborting on get_primary()'s error.
                 last = str(exc)
+                time.sleep(2)
                 continue
             # HAProxy can't detect the primary itself; (re-)pin the write backend to the
             # current primary each iteration. Idempotent, and self-heals after failover.

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -711,10 +711,14 @@ class GroupReplication:
                     f"expected {expected_local!r}"
                 )
 
-        primary = self.primary()
+        if not self.active_nodes:
+            raise RuntimeError("No active nodes to query membership")
+        # Query a currently-active node, not self.primary() (the bootstrap node), which may
+        # be intentionally stopped during failover testing while other members are ONLINE.
+        query_node = self.active_nodes[0]
         self.log("check membership via replication_group_members")
         result = self.docker.exec_mysql(
-            primary,
+            query_node,
             "SELECT MEMBER_HOST, MEMBER_PORT, MEMBER_STATE, MEMBER_ROLE "
             "FROM performance_schema.replication_group_members;",
             password=self.root_password,

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -168,8 +168,12 @@ class GroupReplication:
             time.sleep(2)
         raise RuntimeError(f"Container {name} did not become ready in {timeout}s. Last: {last_err}")
 
-    def primary(self) -> str:
-        """Return the bootstrap node name (the first container created)."""
+    def get_bootstrap_node(self) -> str:
+        """Return the bootstrap node name (the first container created).
+
+        This is a fixed node, distinct from get_primary(), which queries the cluster for
+        the currently-elected ONLINE primary (they differ after a failover).
+        """
         if not self.containers:
             raise RuntimeError("Cluster not created yet")
         return self.containers[0]
@@ -613,27 +617,27 @@ class GroupReplication:
         for name in self.containers:
             self._wait_ready(name)
 
-        primary = self.primary()
+        bootstrap_node = self.get_bootstrap_node()
         bootstrap_opts = (
             f"groupName:{self._js_str(self.group_name)},"
             f"communicationStack:{self._js_str(self.communication_stack)},"
-            f"localAddress:{self._js_str(self._gr_address(primary))},"
+            f"localAddress:{self._js_str(self._gr_address(bootstrap_node))},"
             f"multiPrimary:{'false' if self.single_primary else 'true'}"
         )
         bootstrap_script = (
             f"var c = dba.createCluster({self._js_str(self.cluster_name)}, {{{bootstrap_opts}}});"
         )
-        self.log(f"bootstrap cluster on {primary}")
-        self.docker.exec_mysqlsh(primary, bootstrap_script, password=self.root_password)
+        self.log(f"bootstrap cluster on {bootstrap_node}")
+        self.docker.exec_mysqlsh(bootstrap_node, bootstrap_script, password=self.root_password)
         for i in range(2, self.num_nodes + 1):
             node = self._node_name(i)
             self.log(f"add {node} to cluster (clone)")
             self.docker.exec_mysqlsh(
-                primary, self._add_instance_script(node), password=self.root_password
+                bootstrap_node, self._add_instance_script(node), password=self.root_password
             )
 
         status = self.docker.exec_mysqlsh(
-            primary,
+            bootstrap_node,
             f"var c = dba.getCluster({self._js_str(self.cluster_name)}); "
             "print(JSON.stringify(c.status()));",
             password=self.root_password,
@@ -713,8 +717,8 @@ class GroupReplication:
 
         if not self.active_nodes:
             raise RuntimeError("No active nodes to query membership")
-        # Query a currently-active node, not self.primary() (the bootstrap node), which may
-        # be intentionally stopped during failover testing while other members are ONLINE.
+        # Query a currently-active node, not self.get_bootstrap_node(), which may be
+        # intentionally stopped during failover testing while other members are ONLINE.
         query_node = self.active_nodes[0]
         self.log("check membership via replication_group_members")
         result = self.docker.exec_mysql(

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -187,6 +187,8 @@ class GroupReplication:
 
     def wait_all_online(self, timeout: int = 180) -> None:
         """Wait until every expected member reports the ONLINE state, or time out."""
+        if not self.active_nodes:
+            raise RuntimeError("No active nodes")
         self.log("wait for all members ONLINE")
         deadline = time.time() + timeout
         last: dict[str, str] = {}

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -53,6 +53,9 @@ class GroupReplication:
         self.num_nodes = num_nodes
         self.network = network
         self.server_image = server_image or os.environ.get("SERVER_IMAGE") or "percona/percona-server:8.4"
+        allowed = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-")
+        if not node_prefix or not node_prefix[0].isalnum() or any(c not in allowed for c in node_prefix):
+            raise ValueError("node_prefix must start with an alphanumeric and contain only [A-Za-z0-9_.-]")
         self.node_prefix = node_prefix
         self.root_password = root_password
         self.base_host_port = base_host_port

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -618,10 +618,13 @@ class GroupReplication:
         isolation. Returns the container name; it is not tracked in self.containers.
         """
         self.log(f"start standalone node {name} (restored data, GR off)")
+        # No --hostname: the caller's container name (derived from the test id) may contain
+        # underscores or exceed the 63-char hostname limit, which would make container
+        # creation fail. The node isn't on the cluster network and nothing addresses it by
+        # hostname (it's reached by container name), so the default hostname is fine.
         self.docker.create(
             image=self.server_image,
             name=name,
-            hostname=name,
             # Ignored for a pre-populated (restored) datadir, but lets the image's
             # entrypoint initialize successfully if the volume is empty/partial — otherwise
             # init fails, mysqld never starts, and _wait_ready hangs until it times out.

--- a/test_scripts/ps/group-replication/group_replication_helper.py
+++ b/test_scripts/ps/group-replication/group_replication_helper.py
@@ -653,12 +653,18 @@ class GroupReplication:
             self.wait_proxy_ready()
 
     def _read_variables(self, name: str, variables: list[str]) -> dict[str, str]:
-        """Read the given global variables from a node as a name->value map."""
+        """Read the given global variables from a node as a name->value map.
+
+        Uses check=False so a transient failure (node down/restarting) yields an empty
+        map rather than raising — verify() then records the missing values as structured
+        mismatches instead of crashing before it can report the collected errors.
+        """
         in_clause = ",".join(f"'{v}'" for v in variables)
         result = self.docker.exec_mysql(
             name,
             f"SHOW GLOBAL VARIABLES WHERE Variable_name IN ({in_clause});",
             password=self.root_password,
+            check=False,
         )
         actual: dict[str, str] = {}
         for line in result.stdout.strip().splitlines():

--- a/test_scripts/ps/group-replication/pytest.ini
+++ b/test_scripts/ps/group-replication/pytest.ini
@@ -2,3 +2,7 @@
 testpaths = .
 python_files = test_*.py
 addopts = -v -ra
+log_cli = true
+log_cli_level = INFO
+log_cli_format = %(asctime)s.%(msecs)03d [%(name)s] %(message)s
+log_cli_date_format = %Y-%m-%d %H:%M:%S

--- a/test_scripts/ps/group-replication/pytest.ini
+++ b/test_scripts/ps/group-replication/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = .
+python_files = test_*.py
+addopts = -v -ra

--- a/test_scripts/ps/group-replication/requirements.txt
+++ b/test_scripts/ps/group-replication/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=8
+pytest-timeout>=2

--- a/test_scripts/ps/group-replication/sysbench_helper.py
+++ b/test_scripts/ps/group-replication/sysbench_helper.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Callable
 
 from docker_helper import DockerHelper
@@ -9,7 +10,7 @@ class Sysbench:
         docker: DockerHelper,
         network: str,
         name: str,
-        image: str = "pingwinator/sysbench:latest",
+        image: str | None = None,
         mysql_user: str = "sysbench",
         mysql_password: str = "sysbench",
         database: str = "sbtest",
@@ -21,7 +22,7 @@ class Sysbench:
         self.docker = docker
         self.network = network
         self.name = name
-        self.image = image
+        self.image = image or os.environ.get("SYSBENCH_IMAGE") or "pingwinator/sysbench:latest"
         self.mysql_user = mysql_user
         self.mysql_password = mysql_password
         self.database = database

--- a/test_scripts/ps/group-replication/sysbench_helper.py
+++ b/test_scripts/ps/group-replication/sysbench_helper.py
@@ -30,12 +30,12 @@ class Sysbench:
         self.threads = threads
         self.log = log or (lambda msg: None)
 
-    def _args(self, host: str, workload: str) -> list[str]:
+    def _args(self, host: str, workload: str, port: int = 3306) -> list[str]:
         return [
             workload,
             "--db-driver=mysql",
             f"--mysql-host={host}",
-            "--mysql-port=3306",
+            f"--mysql-port={port}",
             f"--mysql-user={self.mysql_user}",
             f"--mysql-password={self.mysql_password}",
             f"--mysql-db={self.database}",
@@ -54,13 +54,13 @@ class Sysbench:
             check=True,
         )
 
-    def prepare(self, host: str, workload: str = "oltp_read_write"):
-        self.log(f"sysbench prepare ({self.tables} tables x {self.table_size} rows) on {host}")
-        return self._exec(self._args(host, workload) + ["prepare"])
+    def prepare(self, host: str, workload: str = "oltp_read_write", port: int = 3306):
+        self.log(f"sysbench prepare ({self.tables} tables x {self.table_size} rows) on {host}:{port}")
+        return self._exec(self._args(host, workload, port) + ["prepare"])
 
-    def run(self, host: str, workload: str = "oltp_read_write", time: int = 20):
-        self.log(f"sysbench {workload} run for {time}s ({self.threads} threads) on {host}")
+    def run(self, host: str, workload: str = "oltp_read_write", time: int = 20, port: int = 3306):
+        self.log(f"sysbench {workload} run for {time}s ({self.threads} threads) on {host}:{port}")
         return self._exec(
-            self._args(host, workload)
+            self._args(host, workload, port)
             + [f"--threads={self.threads}", f"--time={time}", "--report-interval=5", "run"]
         )

--- a/test_scripts/ps/group-replication/sysbench_helper.py
+++ b/test_scripts/ps/group-replication/sysbench_helper.py
@@ -1,0 +1,66 @@
+from collections.abc import Callable
+
+from docker_helper import DockerHelper
+
+
+class Sysbench:
+    def __init__(
+        self,
+        docker: DockerHelper,
+        network: str,
+        name: str,
+        image: str = "pingwinator/sysbench:latest",
+        mysql_user: str = "sysbench",
+        mysql_password: str = "sysbench",
+        database: str = "sbtest",
+        tables: int = 4,
+        table_size: int = 10000,
+        threads: int = 4,
+        log: Callable[[str], None] | None = None,
+    ):
+        self.docker = docker
+        self.network = network
+        self.name = name
+        self.image = image
+        self.mysql_user = mysql_user
+        self.mysql_password = mysql_password
+        self.database = database
+        self.tables = tables
+        self.table_size = table_size
+        self.threads = threads
+        self.log = log or (lambda msg: None)
+
+    def _args(self, host: str, workload: str) -> list[str]:
+        return [
+            workload,
+            "--db-driver=mysql",
+            f"--mysql-host={host}",
+            "--mysql-port=3306",
+            f"--mysql-user={self.mysql_user}",
+            f"--mysql-password={self.mysql_password}",
+            f"--mysql-db={self.database}",
+            f"--tables={self.tables}",
+            f"--table-size={self.table_size}",
+        ]
+
+    def _exec(self, command: list[str]):
+        return self.docker.run(
+            self.image,
+            name=self.name,
+            networks=[self.network],
+            entrypoint="sysbench",
+            command=command,
+            remove=True,
+            check=True,
+        )
+
+    def prepare(self, host: str, workload: str = "oltp_read_write"):
+        self.log(f"sysbench prepare ({self.tables} tables x {self.table_size} rows) on {host}")
+        return self._exec(self._args(host, workload) + ["prepare"])
+
+    def run(self, host: str, workload: str = "oltp_read_write", time: int = 20):
+        self.log(f"sysbench {workload} run for {time}s ({self.threads} threads) on {host}")
+        return self._exec(
+            self._args(host, workload)
+            + [f"--threads={self.threads}", f"--time={time}", "--report-interval=5", "run"]
+        )

--- a/test_scripts/ps/group-replication/sysbench_helper.py
+++ b/test_scripts/ps/group-replication/sysbench_helper.py
@@ -48,7 +48,7 @@ class Sysbench:
         return self.docker.run(
             self.image,
             name=self.name,
-            networks=[self.network],
+            network=self.network,
             entrypoint="sysbench",
             command=command,
             remove=True,

--- a/test_scripts/ps/group-replication/test_backup_restore.py
+++ b/test_scripts/ps/group-replication/test_backup_restore.py
@@ -1,0 +1,59 @@
+"""Group Replication XtraBackup full + incremental backup/restore test.
+
+Takes a full backup of a cluster secondary, runs more load, takes an incremental
+backup, then (after yet more load) prepares and restores the full+incremental chain
+into a fresh standalone node. Confirms the restored data matches the cluster's state as
+of the incremental backup (a point-in-time check), and that the live cluster is
+unaffected and group replication still healthy. Runs behind HAProxy only — the proxy is
+irrelevant to backup/restore.
+"""
+
+import pytest
+
+
+@pytest.mark.parametrize("gr_cluster", ["haproxy"], indirect=True)
+def test_full_and_incremental_backup_restore(gr_cluster, sysbench, xtrabackup):
+    # Healthy 3-node cluster to start from.
+    gr_cluster.verify()
+
+    # Initial data load via sysbench (4 tables x 10000 rows) through the read/write endpoint.
+    host, port = gr_cluster.rw_endpoint()
+    sysbench.prepare(host=host, port=port)
+    gr_cluster.verify_checksums("sbtest", timeout=120)
+
+    # Back up a secondary (never the primary); XtraBackup reads its data volume directly.
+    secondary = gr_cluster.secondaries()[0]
+    src_vol = gr_cluster._volume_name(gr_cluster.node_index[secondary])
+
+    # Full backup of the current data (set A).
+    xtrabackup.helper.full_backup(secondary, src_vol)
+
+    # More load (set B), and make sure the secondary has fully applied it.
+    sysbench.run(host=host, port=port, time=20)
+    gr_cluster.verify_checksums("sbtest", timeout=120)
+
+    # Incremental backup capturing set B, and snapshot that point-in-time state.
+    xtrabackup.helper.incremental_backup(secondary, src_vol)
+    snapshot = gr_cluster.table_checksums(secondary, "sbtest")
+
+    # Yet more load (set C) — this is intentionally NOT in the backup chain.
+    sysbench.run(host=host, port=port, time=20)
+    gr_cluster.verify_checksums("sbtest", timeout=120)
+
+    # Prepare the full+incremental chain and restore it into a fresh standalone node.
+    xtrabackup.helper.prepare()
+    xtrabackup.helper.copy_back(xtrabackup.restore_volume)
+    node = gr_cluster.start_standalone_node(
+        xtrabackup.restore_container, xtrabackup.restore_volume
+    )
+
+    # The restored data equals the state at incremental-backup time (set B), not the
+    # later set C — proving a real point-in-time restore, not just any consistent state.
+    restored = gr_cluster.table_checksums(node, "sbtest")
+    assert restored == snapshot, (
+        f"restored data mismatch:\n  restored={restored}\n  snapshot={snapshot}"
+    )
+
+    # The live cluster was never disrupted and group replication is still healthy.
+    gr_cluster.verify()
+    gr_cluster.verify_checksums("sbtest", timeout=120)

--- a/test_scripts/ps/group-replication/test_backup_restore.py
+++ b/test_scripts/ps/group-replication/test_backup_restore.py
@@ -22,8 +22,10 @@ def test_full_and_incremental_backup_restore(gr_cluster, sysbench, xtrabackup):
     gr_cluster.verify_checksums("sbtest", timeout=120)
 
     # Back up a secondary (never the primary); XtraBackup reads its data volume directly.
+    # The data volume follows the "<container>-data" convention, so derive it from the node
+    # name rather than reaching into GroupReplication internals.
     secondary = gr_cluster.secondaries()[0]
-    src_vol = gr_cluster._volume_name(gr_cluster.node_index[secondary])
+    src_vol = f"{secondary}-data"
 
     # Full backup of the current data (set A).
     xtrabackup.helper.full_backup(secondary, src_vol)

--- a/test_scripts/ps/group-replication/test_basic.py
+++ b/test_scripts/ps/group-replication/test_basic.py
@@ -7,24 +7,15 @@ the data replicates identically (matching checksums) to all nodes.
 
 
 def test_replicates_table_across_nodes(gr_cluster):
-    primary = gr_cluster.primary()
-    docker = gr_cluster.docker
-
     gr_cluster.verify()
 
     gr_cluster.log("create database gr_test")
-    docker.exec_mysql(primary, "CREATE DATABASE IF NOT EXISTS gr_test;")
+    gr_cluster.exec_sql("CREATE DATABASE IF NOT EXISTS gr_test;")
 
     gr_cluster.log("create table gr_test.t")
-    docker.exec_mysql(
-        primary,
-        "CREATE TABLE gr_test.t (id INT PRIMARY KEY, v VARCHAR(32));",
-    )
+    gr_cluster.exec_sql("CREATE TABLE gr_test.t (id INT PRIMARY KEY, v VARCHAR(32));")
 
     gr_cluster.log("insert 3 rows into gr_test.t")
-    docker.exec_mysql(
-        primary,
-        "INSERT INTO gr_test.t VALUES (1,'a'),(2,'b'),(3,'c');",
-    )
+    gr_cluster.exec_sql("INSERT INTO gr_test.t VALUES (1,'a'),(2,'b'),(3,'c');")
 
     gr_cluster.verify_checksums("gr_test")

--- a/test_scripts/ps/group-replication/test_basic.py
+++ b/test_scripts/ps/group-replication/test_basic.py
@@ -1,0 +1,30 @@
+import time
+
+
+def _count_with_retry(docker, node, table_fqn, expected, timeout=30):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        result = docker.exec_mysql(node, f"SELECT COUNT(*) FROM {table_fqn};", check=False)
+        last = result.stdout.strip()
+        if result.ok and last == str(expected):
+            return last
+        time.sleep(1)
+    return last
+
+
+def test_replicates_table_across_nodes(gr_cluster):
+    primary = gr_cluster.primary()
+    docker = gr_cluster.docker
+
+    gr_cluster.verify()
+
+    docker.exec_mysql(primary, "CREATE DATABASE IF NOT EXISTS gr_test;")
+    docker.exec_mysql(
+        primary,
+        "CREATE TABLE gr_test.t (id INT PRIMARY KEY, v VARCHAR(32));",
+    )
+    docker.exec_mysql(
+        primary,
+        "INSERT INTO gr_test.t VALUES (1,'a'),(2,'b'),(3,'c');",
+    )

--- a/test_scripts/ps/group-replication/test_basic.py
+++ b/test_scripts/ps/group-replication/test_basic.py
@@ -1,18 +1,3 @@
-import time
-
-
-def _count_with_retry(docker, node, table_fqn, expected, timeout=30):
-    deadline = time.time() + timeout
-    last = None
-    while time.time() < deadline:
-        result = docker.exec_mysql(node, f"SELECT COUNT(*) FROM {table_fqn};", check=False)
-        last = result.stdout.strip()
-        if result.ok and last == str(expected):
-            return last
-        time.sleep(1)
-    return last
-
-
 def test_replicates_table_across_nodes(gr_cluster):
     primary = gr_cluster.primary()
     docker = gr_cluster.docker
@@ -28,3 +13,5 @@ def test_replicates_table_across_nodes(gr_cluster):
         primary,
         "INSERT INTO gr_test.t VALUES (1,'a'),(2,'b'),(3,'c');",
     )
+
+    gr_cluster.verify_checksums("gr_test")

--- a/test_scripts/ps/group-replication/test_basic.py
+++ b/test_scripts/ps/group-replication/test_basic.py
@@ -5,7 +5,10 @@ membership, then creates a database/table and inserts rows on the primary and co
 the data replicates identically (matching checksums) to all nodes.
 """
 
+import pytest
 
+
+@pytest.mark.parametrize("gr_cluster", ["router", "haproxy"], indirect=True)
 def test_replicates_table_across_nodes(gr_cluster):
     gr_cluster.verify()
 

--- a/test_scripts/ps/group-replication/test_basic.py
+++ b/test_scripts/ps/group-replication/test_basic.py
@@ -1,3 +1,11 @@
+"""Basic Group Replication sanity test.
+
+Verifies that a freshly bootstrapped cluster has the expected GR configuration and
+membership, then creates a database/table and inserts rows on the primary and confirms
+the data replicates identically (matching checksums) to all nodes.
+"""
+
+
 def test_replicates_table_across_nodes(gr_cluster):
     primary = gr_cluster.primary()
     docker = gr_cluster.docker

--- a/test_scripts/ps/group-replication/test_basic.py
+++ b/test_scripts/ps/group-replication/test_basic.py
@@ -4,11 +4,16 @@ def test_replicates_table_across_nodes(gr_cluster):
 
     gr_cluster.verify()
 
+    gr_cluster.log("create database gr_test")
     docker.exec_mysql(primary, "CREATE DATABASE IF NOT EXISTS gr_test;")
+
+    gr_cluster.log("create table gr_test.t")
     docker.exec_mysql(
         primary,
         "CREATE TABLE gr_test.t (id INT PRIMARY KEY, v VARCHAR(32));",
     )
+
+    gr_cluster.log("insert 3 rows into gr_test.t")
     docker.exec_mysql(
         primary,
         "INSERT INTO gr_test.t VALUES (1,'a'),(2,'b'),(3,'c');",

--- a/test_scripts/ps/group-replication/test_failover.py
+++ b/test_scripts/ps/group-replication/test_failover.py
@@ -21,15 +21,21 @@ def test_primary_failover_and_recovery(gr_cluster, sysbench):
     # Stop the primary and confirm a secondary is promoted.
     old_primary = gr_cluster.get_primary()
     gr_cluster.stop_node(old_primary)
+
+    # The remaining two members keep majority; confirm the group settles to exactly
+    # 2 ONLINE members (the stopped node dropping out) before a new primary is elected.
+    states = gr_cluster.wait_online_count(2)
+    online_hosts = [host for host, (state, _) in states.items() if state == "ONLINE"]
+    assert old_primary not in online_hosts, f"stopped node {old_primary} still ONLINE: {states}"
+
     new_primary = gr_cluster.get_primary()
     assert new_primary != old_primary, f"primary did not change after stopping {old_primary}"
     assert new_primary in gr_cluster.active_nodes
 
-    # With the third node stopped on purpose, exactly 2 members must remain:
-    # both ONLINE, one PRIMARY (the newly elected one) and one SECONDARY.
+    # The two surviving members must be exactly one PRIMARY (the newly elected one)
+    # and one SECONDARY.
     members = gr_cluster.member_states(new_primary)
     online = {host: role for host, (state, role) in members.items() if state == "ONLINE"}
-    assert len(online) == 2, f"expected 2 ONLINE members after failover, got {members}"
     assert sorted(online.values()) == ["PRIMARY", "SECONDARY"], (
         f"expected one PRIMARY and one SECONDARY, got {members}"
     )

--- a/test_scripts/ps/group-replication/test_failover.py
+++ b/test_scripts/ps/group-replication/test_failover.py
@@ -25,6 +25,16 @@ def test_primary_failover_and_recovery(gr_cluster, sysbench):
     assert new_primary != old_primary, f"primary did not change after stopping {old_primary}"
     assert new_primary in gr_cluster.active_nodes
 
+    # With the third node stopped on purpose, exactly 2 members must remain:
+    # both ONLINE, one PRIMARY (the newly elected one) and one SECONDARY.
+    members = gr_cluster.member_states(new_primary)
+    online = {host: role for host, (state, role) in members.items() if state == "ONLINE"}
+    assert len(online) == 2, f"expected 2 ONLINE members after failover, got {members}"
+    assert sorted(online.values()) == ["PRIMARY", "SECONDARY"], (
+        f"expected one PRIMARY and one SECONDARY, got {members}"
+    )
+    assert online.get(new_primary) == "PRIMARY"
+
     # The read/write endpoint must follow the failover before we load again
     # (the proxy needs a moment to repoint at the new primary).
     if gr_cluster.proxy:

--- a/test_scripts/ps/group-replication/test_failover.py
+++ b/test_scripts/ps/group-replication/test_failover.py
@@ -1,0 +1,27 @@
+def test_primary_failover_and_recovery(gr_cluster, sysbench):
+    gr_cluster.verify()
+
+    # Initial data load via sysbench (4 tables x 10000 rows).
+    sysbench.prepare(host=gr_cluster.get_primary())
+    gr_cluster.verify_checksums("sbtest", timeout=120)
+
+    # Stop the primary and confirm a secondary is promoted.
+    old_primary = gr_cluster.get_primary()
+    gr_cluster.stop_node(old_primary)
+    new_primary = gr_cluster.get_primary()
+    assert new_primary != old_primary, f"primary did not change after stopping {old_primary}"
+    assert new_primary in gr_cluster.active_nodes
+
+    # Load against the new primary; data stays consistent across the online nodes.
+    sysbench.run(host=new_primary, time=20)
+    gr_cluster.verify_checksums("sbtest", timeout=120)
+
+    # Bring the stopped node back; it auto-rejoins and the cluster is whole again.
+    gr_cluster.rejoin_node(old_primary)
+    gr_cluster.wait_all_online()
+    gr_cluster.verify()
+    gr_cluster.verify_checksums("sbtest", timeout=120)
+
+    # Load against the full cluster; data stays consistent across all nodes.
+    sysbench.run(host=gr_cluster.get_primary(), time=20)
+    gr_cluster.verify_checksums("sbtest", timeout=120)

--- a/test_scripts/ps/group-replication/test_failover.py
+++ b/test_scripts/ps/group-replication/test_failover.py
@@ -1,7 +1,7 @@
 """Group Replication primary failover and recovery test.
 
 Loads data via sysbench, stops the current primary to force the election of a new one,
-and keeps writing through the failover. Then brings the stopped node back, confirms it
+then resumes writes after the failover. Brings the stopped node back, confirms it
 auto-rejoins and the cluster is whole again, verifying data stays consistent across all
 online nodes (matching checksums) at every stage.
 """

--- a/test_scripts/ps/group-replication/test_failover.py
+++ b/test_scripts/ps/group-replication/test_failover.py
@@ -1,3 +1,12 @@
+"""Group Replication primary failover and recovery test.
+
+Loads data via sysbench, stops the current primary to force the election of a new one,
+and keeps writing through the failover. Then brings the stopped node back, confirms it
+auto-rejoins and the cluster is whole again, verifying data stays consistent across all
+online nodes (matching checksums) at every stage.
+"""
+
+
 def test_primary_failover_and_recovery(gr_cluster, sysbench):
     gr_cluster.verify()
 

--- a/test_scripts/ps/group-replication/test_failover.py
+++ b/test_scripts/ps/group-replication/test_failover.py
@@ -23,9 +23,9 @@ def test_primary_failover_and_recovery(gr_cluster, sysbench):
     assert new_primary in gr_cluster.active_nodes
 
     # The read/write endpoint must follow the failover before we load again
-    # (the router needs a moment to repoint 6446 at the new primary).
-    if gr_cluster.mysql_router:
-        gr_cluster._wait_router_ready()
+    # (the proxy needs a moment to repoint at the new primary).
+    if gr_cluster.proxy:
+        gr_cluster.wait_proxy_ready()
 
     # Load against the new primary; data stays consistent across the online nodes.
     host, port = gr_cluster.rw_endpoint()

--- a/test_scripts/ps/group-replication/test_failover.py
+++ b/test_scripts/ps/group-replication/test_failover.py
@@ -6,7 +6,10 @@ auto-rejoins and the cluster is whole again, verifying data stays consistent acr
 online nodes (matching checksums) at every stage.
 """
 
+import pytest
 
+
+@pytest.mark.parametrize("gr_cluster", ["router", "haproxy"], indirect=True)
 def test_primary_failover_and_recovery(gr_cluster, sysbench):
     gr_cluster.verify()
 

--- a/test_scripts/ps/group-replication/test_failover.py
+++ b/test_scripts/ps/group-replication/test_failover.py
@@ -10,8 +10,9 @@ online nodes (matching checksums) at every stage.
 def test_primary_failover_and_recovery(gr_cluster, sysbench):
     gr_cluster.verify()
 
-    # Initial data load via sysbench (4 tables x 10000 rows).
-    sysbench.prepare(host=gr_cluster.get_primary())
+    # Initial data load via sysbench (4 tables x 10000 rows) through the read/write endpoint.
+    host, port = gr_cluster.rw_endpoint()
+    sysbench.prepare(host=host, port=port)
     gr_cluster.verify_checksums("sbtest", timeout=120)
 
     # Stop the primary and confirm a secondary is promoted.
@@ -21,8 +22,14 @@ def test_primary_failover_and_recovery(gr_cluster, sysbench):
     assert new_primary != old_primary, f"primary did not change after stopping {old_primary}"
     assert new_primary in gr_cluster.active_nodes
 
+    # The read/write endpoint must follow the failover before we load again
+    # (the router needs a moment to repoint 6446 at the new primary).
+    if gr_cluster.mysql_router:
+        gr_cluster._wait_router_ready()
+
     # Load against the new primary; data stays consistent across the online nodes.
-    sysbench.run(host=new_primary, time=20)
+    host, port = gr_cluster.rw_endpoint()
+    sysbench.run(host=host, port=port, time=20)
     gr_cluster.verify_checksums("sbtest", timeout=120)
 
     # Bring the stopped node back; it auto-rejoins and the cluster is whole again.
@@ -32,5 +39,6 @@ def test_primary_failover_and_recovery(gr_cluster, sysbench):
     gr_cluster.verify_checksums("sbtest", timeout=120)
 
     # Load against the full cluster; data stays consistent across all nodes.
-    sysbench.run(host=gr_cluster.get_primary(), time=20)
+    host, port = gr_cluster.rw_endpoint()
+    sysbench.run(host=host, port=port, time=20)
     gr_cluster.verify_checksums("sbtest", timeout=120)

--- a/test_scripts/ps/group-replication/test_scaling.py
+++ b/test_scripts/ps/group-replication/test_scaling.py
@@ -1,7 +1,7 @@
 """Group Replication scale up / scale down test.
 
-Starts from a 3-node cluster, loads data via sysbench, then grows the cluster to 5
-nodes and shrinks it back to 3 while a workload runs. Confirms membership and cluster
+Starts from a 3-node cluster, loads data via sysbench, scales the cluster up to 5
+nodes, runs a workload, then scales it back down to 3. Confirms membership and cluster
 configuration are correct after each change and that data stays consistent (matching
 checksums) across all online nodes at every stage, behind both proxy backends.
 """

--- a/test_scripts/ps/group-replication/test_scaling.py
+++ b/test_scripts/ps/group-replication/test_scaling.py
@@ -1,0 +1,37 @@
+"""Group Replication scale up / scale down test.
+
+Starts from a 3-node cluster, loads data via sysbench, then grows the cluster to 5
+nodes and shrinks it back to 3 while a workload runs. Confirms membership and cluster
+configuration are correct after each change and that data stays consistent (matching
+checksums) across all online nodes at every stage, behind both proxy backends.
+"""
+
+import pytest
+
+
+@pytest.mark.parametrize("gr_cluster", ["router", "haproxy"], indirect=True)
+def test_scale_up_and_down(gr_cluster, sysbench):
+    # Healthy 3-node cluster to start from.
+    gr_cluster.verify()
+
+    # Initial data load via sysbench (4 tables x 10000 rows) through the read/write endpoint.
+    host, port = gr_cluster.rw_endpoint()
+    sysbench.prepare(host=host, port=port)
+    gr_cluster.verify_checksums("sbtest", timeout=120)
+
+    # Scale up by 2 (3 -> 5 nodes); the freshly cloned secondaries must catch up.
+    gr_cluster.scale_up(2)
+    gr_cluster.verify()
+    assert gr_cluster.num_nodes == 5
+    gr_cluster.verify_checksums("sbtest", timeout=180)
+
+    # Run an OLTP read/write workload against the grown cluster; data stays consistent.
+    host, port = gr_cluster.rw_endpoint()
+    sysbench.run(host=host, port=port, time=20)
+    gr_cluster.verify_checksums("sbtest", timeout=120)
+
+    # Scale down by 2 (5 -> 3 nodes); the cluster configuration is correct afterwards.
+    gr_cluster.scale_down(2)
+    gr_cluster.verify()
+    assert gr_cluster.num_nodes == 3
+    gr_cluster.verify_checksums("sbtest", timeout=120)

--- a/test_scripts/ps/group-replication/xtrabackup_helper.py
+++ b/test_scripts/ps/group-replication/xtrabackup_helper.py
@@ -102,13 +102,17 @@ class XtraBackup:
         )
 
     def copy_back(self, target_volume: str):
-        """Restore the prepared backup into an empty target volume and fix ownership.
+        """Restore the prepared backup into the target volume and fix ownership.
 
-        chown to mysql:mysql works because the XtraBackup and Percona Server images
-        share the same mysql user, so the restored datadir is readable by the server.
+        The named target volume may survive a crashed run (teardown didn't remove it), and
+        --copy-back requires an empty datadir, so the mount's contents are cleared first
+        (including dotfiles, while keeping the mountpoint) to keep restores idempotent.
+        chown to mysql:mysql works because the XtraBackup and Percona Server images share
+        the same mysql user, so the restored datadir is readable by the server.
         """
         self.log(f"xtrabackup copy-back {self.full_dir} -> {target_volume}")
         command = (
+            "find /var/lib/mysql -mindepth 1 -maxdepth 1 -exec rm -rf {} + && "
             f"xtrabackup --copy-back --target-dir={self.full_dir} --datadir=/var/lib/mysql && "
             "chown -R mysql:mysql /var/lib/mysql"
         )

--- a/test_scripts/ps/group-replication/xtrabackup_helper.py
+++ b/test_scripts/ps/group-replication/xtrabackup_helper.py
@@ -1,0 +1,119 @@
+from collections.abc import Callable
+
+from docker_helper import DockerHelper
+
+
+class XtraBackup:
+    """Percona XtraBackup driver for full + incremental backup and restore.
+
+    Each operation runs as a one-off (--rm) container as root (the user Percona
+    documents for container backups), mounting the relevant data/backup volumes. The
+    backup volume is mounted at /backup, holding the full backup at /backup/full and the
+    incremental at /backup/inc1.
+    """
+
+    def __init__(
+        self,
+        docker: DockerHelper,
+        network: str,
+        backup_volume: str,
+        image: str = "percona/percona-xtrabackup:8.4",
+        platform: str | None = None,
+        root_password: str = "rootpass",
+        name_prefix: str = "xtrabackup",
+        log: Callable[[str], None] | None = None,
+    ):
+        self.docker = docker
+        self.network = network
+        self.backup_volume = backup_volume
+        self.image = image
+        self.platform = platform
+        self.root_password = root_password
+        self.name_prefix = name_prefix
+        self.log = log or (lambda msg: None)
+        self.backup_mount = "/backup"
+        self.full_dir = "/backup/full"
+        self.inc_dir = "/backup/inc1"
+
+    def _run(self, suffix: str, volumes: list[str], command: str, network: str | None = None):
+        """Run a single xtrabackup step in an ephemeral root container."""
+        return self.docker.run(
+            self.image,
+            name=f"{self.name_prefix}_{suffix}",
+            networks=[network] if network else [],
+            entrypoint="bash",
+            command=["-c", command],
+            volumes=volumes,
+            user="root",
+            platform=self.platform,
+            remove=True,
+            check=True,
+        )
+
+    def full_backup(self, source_node: str, source_volume: str):
+        """Take a full backup of source_node, reading its data via the shared volume."""
+        self.log(f"xtrabackup full backup of {source_node} -> {self.full_dir}")
+        command = (
+            f"xtrabackup --backup --datadir=/var/lib/mysql --target-dir={self.full_dir} "
+            f"--host={source_node} --port=3306 --user=root --password={self.root_password}"
+        )
+        return self._run(
+            "full",
+            volumes=[f"{source_volume}:/var/lib/mysql", f"{self.backup_volume}:{self.backup_mount}"],
+            command=command,
+            network=self.network,
+        )
+
+    def incremental_backup(self, source_node: str, source_volume: str):
+        """Take an incremental backup of source_node based on the existing full backup."""
+        self.log(f"xtrabackup incremental backup of {source_node} -> {self.inc_dir}")
+        command = (
+            f"xtrabackup --backup --datadir=/var/lib/mysql --target-dir={self.inc_dir} "
+            f"--incremental-basedir={self.full_dir} "
+            f"--host={source_node} --port=3306 --user=root --password={self.root_password}"
+        )
+        return self._run(
+            "inc",
+            volumes=[f"{source_volume}:/var/lib/mysql", f"{self.backup_volume}:{self.backup_mount}"],
+            command=command,
+            network=self.network,
+        )
+
+    def prepare(self):
+        """Prepare the full backup and merge the incremental into it, ready to restore.
+
+        The base is prepared with --apply-log-only (no rollback yet); the single/last
+        incremental is then merged without --apply-log-only so the final rollback runs
+        and the backup becomes consistent.
+        """
+        self.log("xtrabackup prepare (full + incremental)")
+        command = (
+            f"xtrabackup --prepare --apply-log-only --target-dir={self.full_dir} && "
+            f"xtrabackup --prepare --target-dir={self.full_dir} --incremental-dir={self.inc_dir}"
+        )
+        return self._run(
+            "prepare",
+            volumes=[f"{self.backup_volume}:{self.backup_mount}"],
+            command=command,
+        )
+
+    def copy_back(self, target_volume: str):
+        """Restore the prepared backup into an empty target volume and fix ownership.
+
+        chown to mysql:mysql works because the XtraBackup and Percona Server images
+        share the same mysql user, so the restored datadir is readable by the server.
+        """
+        self.log(f"xtrabackup copy-back {self.full_dir} -> {target_volume}")
+        command = (
+            f"xtrabackup --copy-back --target-dir={self.full_dir} --datadir=/var/lib/mysql && "
+            "chown -R mysql:mysql /var/lib/mysql"
+        )
+        return self._run(
+            "restore",
+            volumes=[f"{target_volume}:/var/lib/mysql", f"{self.backup_volume}:{self.backup_mount}"],
+            command=command,
+        )
+
+    def cleanup(self):
+        """Remove the backup volume."""
+        self.docker.volume_remove(self.backup_volume)

--- a/test_scripts/ps/group-replication/xtrabackup_helper.py
+++ b/test_scripts/ps/group-replication/xtrabackup_helper.py
@@ -41,7 +41,7 @@ class XtraBackup:
         return self.docker.run(
             self.image,
             name=f"{self.name_prefix}_{suffix}",
-            networks=[network] if network else [],
+            network=network,
             entrypoint="bash",
             command=["-c", command],
             volumes=volumes,

--- a/test_scripts/ps/group-replication/xtrabackup_helper.py
+++ b/test_scripts/ps/group-replication/xtrabackup_helper.py
@@ -53,9 +53,16 @@ class XtraBackup:
         )
 
     def full_backup(self, source_node: str, source_volume: str):
-        """Take a full backup of source_node, reading its data via the shared volume."""
+        """Take a full backup of source_node, reading its data via the shared volume.
+
+        xtrabackup --backup aborts if --target-dir exists and is non-empty. The backup
+        volume name is deterministic per test, so a previously-crashed run can leave
+        full/incremental dirs behind; clear and recreate them here (the start of the chain)
+        to keep reruns idempotent.
+        """
         self.log(f"xtrabackup full backup of {source_node} -> {self.full_dir}")
         command = (
+            f"rm -rf {self.full_dir} {self.inc_dir} && mkdir -p {self.full_dir} {self.inc_dir} && "
             f"xtrabackup --backup --datadir=/var/lib/mysql --target-dir={self.full_dir} "
             f"--host={source_node} --port=3306 --user=root "
             f"--password={shlex.quote(self.root_password)}"

--- a/test_scripts/ps/group-replication/xtrabackup_helper.py
+++ b/test_scripts/ps/group-replication/xtrabackup_helper.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Callable
 
 from docker_helper import DockerHelper
@@ -17,7 +18,7 @@ class XtraBackup:
         docker: DockerHelper,
         network: str,
         backup_volume: str,
-        image: str = "percona/percona-xtrabackup:8.4",
+        image: str | None = None,
         platform: str | None = None,
         root_password: str = "rootpass",
         name_prefix: str = "xtrabackup",
@@ -26,7 +27,7 @@ class XtraBackup:
         self.docker = docker
         self.network = network
         self.backup_volume = backup_volume
-        self.image = image
+        self.image = image or os.environ.get("XTRABACKUP_IMAGE") or "percona/percona-xtrabackup:8.4"
         self.platform = platform
         self.root_password = root_password
         self.name_prefix = name_prefix

--- a/test_scripts/ps/group-replication/xtrabackup_helper.py
+++ b/test_scripts/ps/group-replication/xtrabackup_helper.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 from collections.abc import Callable
 
 from docker_helper import DockerHelper
@@ -56,7 +57,8 @@ class XtraBackup:
         self.log(f"xtrabackup full backup of {source_node} -> {self.full_dir}")
         command = (
             f"xtrabackup --backup --datadir=/var/lib/mysql --target-dir={self.full_dir} "
-            f"--host={source_node} --port=3306 --user=root --password={self.root_password}"
+            f"--host={source_node} --port=3306 --user=root "
+            f"--password={shlex.quote(self.root_password)}"
         )
         return self._run(
             "full",
@@ -71,7 +73,8 @@ class XtraBackup:
         command = (
             f"xtrabackup --backup --datadir=/var/lib/mysql --target-dir={self.inc_dir} "
             f"--incremental-basedir={self.full_dir} "
-            f"--host={source_node} --port=3306 --user=root --password={self.root_password}"
+            f"--host={source_node} --port=3306 --user=root "
+            f"--password={shlex.quote(self.root_password)}"
         )
         return self._run(
             "inc",


### PR DESCRIPTION
This creates a pytest framework for running group replication tests with docker images. The purpose is to cover some scenarios which are used in K8S operators.
Docker images which are used can be customized with env variables `SERVER_IMAGE`, `HAPROXY_IMAGE`, `ROUTER_IMAGE`, `XTRABACKUP_IMAGE` and `SYSBENCH_IMAGE`.
The test run with both haproxy and mysql router.

It has helpers for following objects:
- docker
- group replication
- xtrabackup
- sysbench

Initial tests cover:
- basic group replication sanity
- failover with load
- scaling test with load
- backup/restore test with full and incremental backup